### PR TITLE
chore: allinea develop con main (test e refactor PatientModel)

### DIFF
--- a/src/PTRP.Models/PatientModel.cs
+++ b/src/PTRP.Models/PatientModel.cs
@@ -1,14 +1,18 @@
+using System;
+using System.Collections.Generic;
+using PTRP.App.Models;
+
 namespace PTRP.App.Models
 {
     /// <summary>
-    /// Modello per rappresentare un Paziente nell'applicazione
+    /// Modello per rappresentare un Paziente
     /// </summary>
     public class PatientModel
     {
         /// <summary>
         /// Identificatore univoco del paziente
         /// </summary>
-        public int Id { get; set; }
+        public Guid Id { get; set; } = Guid.NewGuid();
 
         /// <summary>
         /// Nome del paziente
@@ -21,53 +25,23 @@ namespace PTRP.App.Models
         public string LastName { get; set; }
 
         /// <summary>
-        /// Data di nascita del paziente
-        /// </summary>
-        public DateTime DateOfBirth { get; set; }
-
-        /// <summary>
-        /// Email di contatto del paziente
-        /// </summary>
-        public string Email { get; set; }
-
-        /// <summary>
-        /// Numero di telefono del paziente
-        /// </summary>
-        public string PhoneNumber { get; set; }
-
-        /// <summary>
         /// Data di creazione del record
         /// </summary>
         public DateTime CreatedAt { get; set; } = DateTime.Now;
 
         /// <summary>
-        /// Data dell'ultimo aggiornamento
+        /// Data dell'ultimo aggiornamento del record
         /// </summary>
         public DateTime? UpdatedAt { get; set; }
 
         /// <summary>
-        /// Proprietà di navigazione per i progetti terapeutici associati
+        /// Collezione di Progetti Terapeutici associati al paziente
         /// </summary>
         public ICollection<TherapyProjectModel> TherapyProjects { get; set; } = new List<TherapyProjectModel>();
 
         /// <summary>
-        /// Override di ToString per visualizzazione rapida
+        /// Rappresentazione testuale del paziente (Nome Cognome)
         /// </summary>
-        public override string ToString()
-        {
-            return $"{FirstName} {LastName} (ID: {Id})";
-        }
-    }
-
-    /// <summary>
-    /// Modello per rappresentare un Progetto Terapeutico (stub per ora)
-    /// </summary>
-    public class TherapyProjectModel
-    {
-        public int Id { get; set; }
-        public string Name { get; set; }
-        public string Description { get; set; }
-        public int PatientId { get; set; }
-        public PatientModel Patient { get; set; }
+        public override string ToString() => $"{FirstName} {LastName}";
     }
 }

--- a/src/PTRP.Services/Interfaces/IPatientService.cs
+++ b/src/PTRP.Services/Interfaces/IPatientService.cs
@@ -1,4 +1,4 @@
-﻿using PTRP.App.Models;
+using PTRP.App.Models;
 
 namespace PTRP.App.Services.Interfaces
 {
@@ -19,7 +19,7 @@ namespace PTRP.App.Services.Interfaces
         /// </summary>
         /// <param name="id">ID del paziente</param>
         /// <returns>PatientModel se trovato, altrimenti null</returns>
-        Task<PatientModel> GetByIdAsync(int id);
+        Task<PatientModel> GetByIdAsync(Guid id);
 
         /// <summary>
         /// Aggiunge un nuovo paziente
@@ -38,7 +38,7 @@ namespace PTRP.App.Services.Interfaces
         /// Elimina un paziente per ID
         /// </summary>
         /// <param name="id">ID del paziente da eliminare</param>
-        Task DeleteAsync(int id);
+        Task DeleteAsync(Guid id);
 
         /// <summary>
         /// Cerca pazienti per nome

--- a/src/PTRP.Services/PatientService.cs
+++ b/src/PTRP.Services/PatientService.cs
@@ -1,4 +1,4 @@
-﻿using PTRP.App.Models;
+using PTRP.App.Models;
 using PTRP.App.Services.Interfaces;
 
 namespace PTRP.App.Services
@@ -18,27 +18,19 @@ namespace PTRP.App.Services
         {
             new PatientModel
             {
-                Id = 1,
+                Id = Guid.Parse("f1234567-89ab-cdef-0123-456789abcdef"),
                 FirstName = "Marco",
                 LastName = "Cavallo",
-                DateOfBirth = new DateTime(1990, 5, 15),
-                Email = "marco.cavallo@example.com",
-                PhoneNumber = "+39 123 456 7890",
                 CreatedAt = DateTime.Now
             },
             new PatientModel
             {
-                Id = 2,
+                Id = Guid.Parse("a0987654-3210-fedc-ba98-765432100abc"),
                 FirstName = "Anna",
                 LastName = "Rossi",
-                DateOfBirth = new DateTime(1988, 3, 22),
-                Email = "anna.rossi@example.com",
-                PhoneNumber = "+39 987 654 3210",
                 CreatedAt = DateTime.Now
             }
         };
-
-        private static int _nextId = 3;
 
         /// <summary>
         /// Costruttore del servizio
@@ -72,7 +64,7 @@ namespace PTRP.App.Services
         /// <summary>
         /// Recupera un paziente per ID
         /// </summary>
-        public async Task<PatientModel> GetByIdAsync(int id)
+        public async Task<PatientModel> GetByIdAsync(Guid id)
         {
             await Task.Delay(50);
 
@@ -95,15 +87,13 @@ namespace PTRP.App.Services
             if (string.IsNullOrWhiteSpace(patient.LastName))
                 throw new ArgumentException("Il cognome è obbligatorio", nameof(patient.LastName));
 
-            if (string.IsNullOrWhiteSpace(patient.Email))
-                throw new ArgumentException("L'email è obbligatoria", nameof(patient.Email));
+            // Se l'ID non è stato impostato, genera un nuovo Guid
+            if (patient.Id == Guid.Empty)
+                patient.Id = Guid.NewGuid();
 
-            if (patient.DateOfBirth >= DateTime.Now)
-                throw new ArgumentException("La data di nascita non può essere nel futuro", nameof(patient.DateOfBirth));
-
-            // Logica di business: setta ID e CreatedAt
-            patient.Id = _nextId++;
-            patient.CreatedAt = DateTime.Now;
+            // Logica di business: setta CreatedAt se non già impostato
+            if (patient.CreatedAt == default)
+                patient.CreatedAt = DateTime.Now;
 
             await Task.Delay(100);
 
@@ -119,7 +109,7 @@ namespace PTRP.App.Services
         /// </summary>
         public async Task UpdateAsync(PatientModel patient)
         {
-            if (patient.Id <= 0)
+            if (patient.Id == Guid.Empty)
                 throw new ArgumentException("ID paziente non valido", nameof(patient.Id));
 
             var existing = _patients.FirstOrDefault(p => p.Id == patient.Id);
@@ -129,9 +119,6 @@ namespace PTRP.App.Services
             // Logica: aggiorna campi e timestamp
             existing.FirstName = patient.FirstName;
             existing.LastName = patient.LastName;
-            existing.DateOfBirth = patient.DateOfBirth;
-            existing.Email = patient.Email;
-            existing.PhoneNumber = patient.PhoneNumber;
             existing.UpdatedAt = DateTime.Now;
 
             await Task.Delay(100);
@@ -143,7 +130,7 @@ namespace PTRP.App.Services
         /// <summary>
         /// Elimina un paziente
         /// </summary>
-        public async Task DeleteAsync(int id)
+        public async Task DeleteAsync(Guid id)
         {
             var patient = _patients.FirstOrDefault(p => p.Id == id);
             if (patient == null)

--- a/tests/PTRP.Tests/Models/PatientModelTests.cs
+++ b/tests/PTRP.Tests/Models/PatientModelTests.cs
@@ -1,0 +1,68 @@
+using PTRP.App.Models;
+
+namespace PTRP.Tests.Models
+{
+    /// <summary>
+    /// Test per la classe PatientModel
+    /// </summary>
+    public class PatientModelTests
+    {
+        [Fact]
+        public void Ctor_CreatesPatientWithValidValues()
+        {
+            // arrange
+            var firstName = "Marco";
+            var lastName = "Cavallo";
+            var now = DateTime.Now;
+
+            // act
+            var patient = new PatientModel
+            {
+                FirstName = firstName,
+                LastName = lastName,
+                CreatedAt = now
+            };
+
+            // assert
+            Assert.NotEqual(Guid.Empty, patient.Id); // Guid generato di default
+            Assert.Equal(firstName, patient.FirstName);
+            Assert.Equal(lastName, patient.LastName);
+            Assert.Equal(now, patient.CreatedAt);
+            Assert.Null(patient.UpdatedAt);
+            Assert.NotNull(patient.TherapyProjects);
+            Assert.Empty(patient.TherapyProjects);
+        }
+
+        [Fact]
+        public void ToString_ReturnsFirstNameAndLastName()
+        {
+            // arrange
+            var patient = new PatientModel
+            {
+                FirstName = "Anna",
+                LastName = "Rossi"
+            };
+
+            var expectedString = "Anna Rossi";
+
+            // act
+            var result = patient.ToString();
+
+            // assert
+            Assert.Equal(expectedString, result);
+        }
+
+        [Fact]
+        public void DefaultValues_AreSetCorrectly()
+        {
+            // arrange & act
+            var patient = new PatientModel();
+
+            // assert
+            Assert.NotEqual(Guid.Empty, patient.Id);
+            Assert.NotEqual(DateTime.MinValue, patient.CreatedAt);
+            Assert.Null(patient.UpdatedAt);
+            Assert.Empty(patient.TherapyProjects);
+        }
+    }
+}

--- a/tests/PTRP.Tests/PTRP.Tests.csproj
+++ b/tests/PTRP.Tests/PTRP.Tests.csproj
@@ -26,4 +26,10 @@
     <Using Include="Xunit" />
   </ItemGroup>
 
+  <!-- Riferimenti ai progetti da testare -->
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\PTRP.Models\PTRP.Models.csproj" />
+    <ProjectReference Include="..\..\src\PTRP.Services\PTRP.Services.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/tests/PTRP.Tests/Services/PatientServiceTests.cs
+++ b/tests/PTRP.Tests/Services/PatientServiceTests.cs
@@ -1,0 +1,152 @@
+using PTRP.App.Models;
+using PTRP.App.Services;
+using PTRP.App.Services.Interfaces;
+
+namespace PTRP.Tests.Services
+{
+    /// <summary>
+    /// Test per la classe PatientService
+    /// </summary>
+    public class PatientServiceTests
+    {
+        private IPatientService CreatePatientService()
+        {
+            return new PatientService();
+        }
+
+        /// <summary>
+        /// Test positivo: aggiunta di un paziente valido
+        /// </summary>
+        [Fact]
+        public async Task AddAsync_WithValidPatient_SuccessfullyAddsPatient()
+        {
+            // arrange
+            var service = CreatePatientService();
+            var newPatient = new PatientModel
+            {
+                FirstName = "Giovanni",
+                LastName = "Bianchi"
+            };
+
+            // act
+            await service.AddAsync(newPatient);
+
+            // assert
+            Assert.NotEqual(Guid.Empty, newPatient.Id);
+            Assert.NotEqual(default, newPatient.CreatedAt);
+
+            // Verifica che il paziente sia recuperabile
+            var retrievedPatient = await service.GetByIdAsync(newPatient.Id);
+            Assert.NotNull(retrievedPatient);
+            Assert.Equal("Giovanni", retrievedPatient.FirstName);
+            Assert.Equal("Bianchi", retrievedPatient.LastName);
+        }
+
+        /// <summary>
+        /// Test di errore: aggiunta paziente con FirstName vuoto
+        /// </summary>
+        [Fact]
+        public async Task AddAsync_WithEmptyFirstName_ThrowsArgumentException()
+        {
+            // arrange
+            var service = CreatePatientService();
+            var invalidPatient = new PatientModel
+            {
+                FirstName = "",
+                LastName = "Rossi"
+            };
+
+            // act & assert
+            var exception = await Assert.ThrowsAsync<ArgumentException>(
+                () => service.AddAsync(invalidPatient)
+            );
+            Assert.Contains("nome", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Test di errore: aggiunta paziente con LastName vuoto
+        /// </summary>
+        [Fact]
+        public async Task AddAsync_WithEmptyLastName_ThrowsArgumentException()
+        {
+            // arrange
+            var service = CreatePatientService();
+            var invalidPatient = new PatientModel
+            {
+                FirstName = "Marco",
+                LastName = ""
+            };
+
+            // act & assert
+            var exception = await Assert.ThrowsAsync<ArgumentException>(
+                () => service.AddAsync(invalidPatient)
+            );
+            Assert.Contains("cognome", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Test positivo: ricerca paziente per ID
+        /// </summary>
+        [Fact]
+        public async Task GetByIdAsync_WithExistingId_ReturnsPatient()
+        {
+            // arrange
+            var service = CreatePatientService();
+            var newPatient = new PatientModel
+            {
+                FirstName = "Lucia",
+                LastName = "Verdi"
+            };
+            await service.AddAsync(newPatient);
+            var patientId = newPatient.Id;
+
+            // act
+            var retrievedPatient = await service.GetByIdAsync(patientId);
+
+            // assert
+            Assert.NotNull(retrievedPatient);
+            Assert.Equal(patientId, retrievedPatient.Id);
+            Assert.Equal("Lucia", retrievedPatient.FirstName);
+        }
+
+        /// <summary>
+        /// Test di errore: eliminazione paziente non trovato
+        /// </summary>
+        [Fact]
+        public async Task DeleteAsync_WithNonExistentId_ThrowsInvalidOperationException()
+        {
+            // arrange
+            var service = CreatePatientService();
+            var nonExistentId = Guid.NewGuid();
+
+            // act & assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => service.DeleteAsync(nonExistentId)
+            );
+            Assert.Contains("non trovato", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Test positivo: ricerca pazienti per nome
+        /// </summary>
+        [Fact]
+        public async Task SearchAsync_WithValidTerm_ReturnsMatchingPatients()
+        {
+            // arrange
+            var service = CreatePatientService();
+            var newPatient = new PatientModel
+            {
+                FirstName = "Paolo",
+                LastName = "Gallo"
+            };
+            await service.AddAsync(newPatient);
+
+            // act
+            var results = await service.SearchAsync("Gallo");
+
+            // assert
+            Assert.NotEmpty(results);
+            Assert.Contains(results, p => p.LastName == "Gallo");
+        }
+    }
+}


### PR DESCRIPTION
## Descrizione

Allinea il branch `develop` con i cambiamenti effettuati su `main`:

### Cambiamenti inclusi:

1. **refactor: aggiorna PatientModel con Guid Id e rimuovi Email, PhoneNumber, DateOfBirth**
   - `Id` cambiato da `int` a `Guid` con default `Guid.NewGuid()`
   - Aggiunto `ICollection<TherapyProjectModel> TherapyProjects`
   - Aggiornato `ToString()` per ritornare solo "FirstName LastName"
   - Rimossi: `Email`, `PhoneNumber`, `DateOfBirth` (riservati agli Educatori)

2. **refactor: aggiorna PatientService e IPatientService da int a Guid**
   - Aggiornati `GetByIdAsync(Guid id)` e `DeleteAsync(Guid id)`
   - Rimossa validazione su `DateOfBirth`
   - Logica di business per generare `Id` e `CreatedAt` durante `AddAsync`

3. **test: aggiungi test minimi per codecoverage**
   - `PatientModelTests`: test constructor, ToString(), default values
   - `PatientServiceTests`: test positivi e di errore per AddAsync, GetByIdAsync, DeleteAsync, SearchAsync
   - Aggiornato `PTRP.Tests.csproj` con ProjectReference a PTRP.Models e PTRP.Services

### Note di sviluppo

D'ora in poi:
- Ogni feature/fix/docs ha origine da `develop`
- Le PR vanno create verso `develop`
- Quando si completa una issue (o un set di issues), si crea PR da `develop` a `main` per release

---

### Commits inclusi:
- f072d8bd8ffff3f572e29ecb3457d62203164dc3: refactor PatientModel
- d7615401a4b7152d69e6ba8c44cf226ac48ebc00: refactor PatientService
- b1b60ad369a2e2a108aee693cc7267c9d6b08d63: refactor IPatientService
- 532226df02e1182976198a8bc2a706090033324f: test PatientModel
- b65d6221c470728e0a32e05ae1a6f7f6b43ec241: test PatientService
- e1f7a1424b42d416566549846d2bdec33243ccae: update PTRP.Tests.csproj
