### PR TITLE
fix: configura Dependency Injection per DbContext e Repository

### DIFF
--- a/src/PTRP.App/App.xaml.cs
+++ b/src/PTRP.App/App.xaml.cs
@@ -1,7 +1,12 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using PTRP.App.Services;
 using PTRP.App.Services.Interfaces;
 using PTRP.App.ViewModels;
+using PTRP.Data;
+using PTRP.Data.Repositories;
+using PTRP.Data.Repositories.Interfaces;
+using System.IO;
 using System.Windows;
 
 namespace PTRP.App
@@ -32,6 +37,9 @@ namespace PTRP.App
             // Costruisce il service provider
             _serviceProvider = services.BuildServiceProvider();
 
+            // Assicura che il database sia creato e migrato
+            EnsureDatabaseCreated();
+
             // Risolve MainWindow con il suo ViewModel iniettato
             var mainWindow = _serviceProvider.GetRequiredService<MainWindow>();
             mainWindow.Show();
@@ -47,6 +55,20 @@ namespace PTRP.App
         /// </summary>
         private void ConfigureServices(ServiceCollection services)
         {
+            // Configura il database SQLite
+            var appDataPath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "PTRP"
+            );
+            Directory.CreateDirectory(appDataPath);
+            var dbPath = Path.Combine(appDataPath, "ptrp.db");
+
+            services.AddDbContext<PTRPDbContext>(options =>
+                options.UseSqlite($"Data Source={dbPath}"));
+
+            // Registra i Repositories
+            services.AddScoped<IPatientRepository, PatientRepository>();
+
             // Registra i Services
             services.AddScoped<IPatientService, PatientService>();
 
@@ -55,6 +77,18 @@ namespace PTRP.App
 
             // Registra le Views
             services.AddScoped<MainWindow>();
+        }
+
+        /// <summary>
+        /// Assicura che il database sia creato e le migrations applicate
+        /// </summary>
+        private void EnsureDatabaseCreated()
+        {
+            using var scope = _serviceProvider.CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<PTRPDbContext>();
+            
+            // Crea il database se non esiste e applica le migrations
+            context.Database.EnsureCreated();
         }
 
         /// <summary>

--- a/src/PTRP.App/PTRP.App.csproj
+++ b/src/PTRP.App/PTRP.App.csproj
@@ -20,8 +20,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PTRP.App/PTRP.App.csproj
+++ b/src/PTRP.App/PTRP.App.csproj
@@ -20,11 +20,14 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\PTRP.Data\PTRP.Data.csproj" />
     <ProjectReference Include="..\PTRP.Models\PTRP.Models.csproj" />
+    <ProjectReference Include="..\PTRP.Services\PTRP.Services.csproj" />
     <ProjectReference Include="..\PTRP.ViewModels\PTRP.ViewModels.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Problema
L'applicazione genera `InvalidOperationException` al runtime:
```
Unable to resolve service for type 'PTRP.Data.Repositories.Interfaces.IPatientRepository' 
while attempting to activate 'PTRP.App.Services.PatientService'.
```

Mancava la configurazione del container DI per registrare DbContext e Repository.

## Soluzione
✅ Aggiunto pacchetto `Microsoft.Extensions.DependencyInjection` v10.0
✅ Aggiunto pacchetto `Microsoft.Extensions.Hosting` v10.0
✅ Aggiunto riferimento a `PTRP.Services` in `PTRP.App`
✅ Configurato `PTRPDbContext` con connection string SQLite in `App.xaml.cs`
✅ Registrato `IPatientRepository` → `PatientRepository` come Scoped
✅ Registrato `IPatientService` → `PatientService` come Scoped
✅ Implementato `EnsureDatabaseCreated()` per auto-creare DB al primo avvio

## Configurazione Database
- **Path**: `%APPDATA%\PTRP\ptrp.db`
- **Provider**: SQLite
- **Auto-creazione**: Sì, con `EnsureCreated()` all'avvio

## Dependency Injection Pattern
```csharp
services.AddDbContext<PTRPDbContext>(options => 
    options.UseSqlite($"Data Source={dbPath}"));

services.AddScoped<IPatientRepository, PatientRepository>();
services.AddScoped<IPatientService, PatientService>();
services.AddScoped<MainWindowViewModel>();
```

## Testing
✅ Build compila
✅ Database viene creato automaticamente in `%APPDATA%\PTRP\`
✅ PatientService risolve correttamente le dipendenze
✅ L'applicazione si avvia senza errori

## Closes
Risolve il runtime error di DI mancante
