### PR TITLE
feat: replace row selection background with chevron icon indicator

### DIFF
--- a/src/PTRP.App/MainWindow.xaml
+++ b/src/PTRP.App/MainWindow.xaml
@@ -55,12 +55,12 @@
             </Setter>
         </Style>
         
-        <!-- Style per riga selezionata con colore più tenue -->
+        <!-- Style per riga selezionata: background rimosso, solo indicatore visuale minimo -->
         <Style x:Key="DataGridRowStyle" TargetType="DataGridRow">
             <Setter Property="Background" Value="White"/>
             <Style.Triggers>
                 <Trigger Property="IsSelected" Value="True">
-                    <Setter Property="Background" Value="#E3F2FD"/>
+                    <Setter Property="Background" Value="White"/>
                     <Setter Property="Foreground" Value="Black"/>
                 </Trigger>
                 <Trigger Property="IsMouseOver" Value="True">
@@ -197,21 +197,30 @@
                   Margin="20">
             
             <DataGrid.Columns>
-                <!-- Indicatore Selezione -->
-                <DataGridTemplateColumn Header="" Width="30">
+                <!-- Indicatore Selezione con Freccia -->
+                <DataGridTemplateColumn Header="" Width="40">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <Border Background="Transparent" Width="4" Height="30" HorizontalAlignment="Left">
-                                <Border.Style>
-                                    <Style TargetType="Border">
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding IsSelected, RelativeSource={RelativeSource AncestorType=DataGridRow}}" Value="True">
-                                                <Setter Property="Background" Value="#007ACC"/>
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </Border.Style>
-                            </Border>
+                            <Grid Background="Transparent" Width="30" Height="30" HorizontalAlignment="Center">
+                                <!-- Freccia verso destra visibile solo quando la riga è selezionata -->
+                                <materialDesign:PackIcon Kind="ChevronRight" 
+                                                         Width="24" 
+                                                         Height="24"
+                                                         Foreground="#007ACC"
+                                                         HorizontalAlignment="Center"
+                                                         VerticalAlignment="Center">
+                                    <materialDesign:PackIcon.Style>
+                                        <Style TargetType="materialDesign:PackIcon">
+                                            <Setter Property="Visibility" Value="Collapsed"/>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsSelected, RelativeSource={RelativeSource AncestorType=DataGridRow}}" Value="True">
+                                                    <Setter Property="Visibility" Value="Visible"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </materialDesign:PackIcon.Style>
+                                </materialDesign:PackIcon>
+                            </Grid>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>


### PR DESCRIPTION
## Descrizione della Modifica

Questa PR risolve il problema di visibilità delle icone sulla destra della griglia quando una riga viene selezionata.

### Problema
Quando una riga veniva selezionata nel DataGrid, il background azzurro coprente (#E3F2FD) rendeva difficile visualizzare le icone di azione (Modifica/Elimina) nella colonna "Azioni".

### Soluzione
- ✅ **Rimosso il background azzurro** dalla riga selezionata nel `DataGridRowStyle`
- ✅ **Aggiunto indicatore visuale alternativo**: Un'icona freccia verso destra (ChevronRight) nella prima colonna vuota
- ✅ **Icona visibile condizionalmente**: L'icona appare solo quando la riga è selezionata
- ✅ **Colore coerente**: L'icona utilizza il colore blu (#007ACC) mantenendo coerenza con il tema dell'app

### Vantaggi
1. Maggiore visibilità delle azioni sulla destra
2. Indicazione chiara e elegante della riga selezionata
3. Design più pulito e meno invasivo
4. Migliore esperienza utente nella gestione dei pazienti

### File Modificati
- `src/PTRP.App/MainWindow.xaml`
  - Modifica del `DataGridRowStyle`: da `#E3F2FD` a `White` quando selezionato
  - Sostituzione della prima colonna con template contenente icona ChevronRight
  - Aumento larghezza della prima colonna da 30 a 40 per alloggiare l'icona

### Testing
Per testare le modifiche:
1. Compilare la soluzione
2. Eseguire l'app
3. Navigare alla sezione "Gestione Pazienti"
4. Cliccare su una riga della griglia
5. Verificare che:
   - L'icona freccia appaia a sinistra quando la riga è selezionata
   - Il background non sia più azzurro
   - Le icone di azione (Modifica/Elimina) siano pienamente visibili

### Note Tecniche
- Utilizzo di `materialDesign:PackIcon` per l'icona ChevronRight
- Binding a `IsSelected` della riga con logica di `Visibility` tramite `DataTrigger`
- Nessuna modifica al code-behind o al ViewModel
- Compatibile con il pattern MVVM esistente
