### PR TITLE
fix: use DataGrid.CellStyle to remove selection background

### DIFF
--- a/src/PTRP.App/MainWindow.xaml
+++ b/src/PTRP.App/MainWindow.xaml
@@ -183,29 +183,18 @@
                   Margin="20"
                   SelectedCellsChanged="PatientsDataGrid_SelectedCellsChanged">
             
-            <!-- Style inline per eliminare il background della riga selezionata -->
-            <DataGrid.RowStyle>
-                <Style TargetType="DataGridRow">
-                    <Setter Property="Background" Value="White"/>
-                    <Setter Property="BorderBrush" Value="Transparent"/>
+            <!-- CellStyle per rimuovere completamente il background della cella selezionata -->
+            <DataGrid.CellStyle>
+                <Style TargetType="{x:Type DataGridCell}">
                     <Style.Triggers>
-                        <!-- Quando la riga è selezionata: NESSUN background azzurro -->
-                        <Trigger Property="IsSelected" Value="True">
-                            <Setter Property="Background" Value="Transparent"/>
+                        <Trigger Property="DataGridCell.IsSelected" Value="True">
                             <Setter Property="BorderBrush" Value="Transparent"/>
-                            <Setter Property="Foreground" Value="Black"/>
-                        </Trigger>
-                        <!-- Hover: sfondo grigio chiaro -->
-                        <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Background" Value="#F5F5F5"/>
-                        </Trigger>
-                        <!-- Focus visivo rimosso -->
-                        <Trigger Property="IsKeyboardFocusWithin" Value="True">
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
                             <Setter Property="Background" Value="Transparent"/>
                         </Trigger>
                     </Style.Triggers>
                 </Style>
-            </DataGrid.RowStyle>
+            </DataGrid.CellStyle>
             
             <DataGrid.Columns>
                 <!-- Indicatore Selezione: Freccia verso destra -->


### PR DESCRIPTION
## Problema

Il precedente approccio con `DataGrid.RowStyle` **non funzionava** per rimuovere il background azzurro sulla riga selezionata in WPF DataGrid.

## Root Cause

WPF DataGrid applica lo stile di selezione a livello di **cella** (`DataGridCell`), non a livello di riga. Tentare di sovrascrivere il background della riga non è sufficiente.

## Soluzione Corretta

✅ **Utilizzare `DataGrid.CellStyle`** invece di `DataGrid.RowStyle`  
✅ **Trigger su `DataGridCell.IsSelected`** per catturare la selezione della cella  
✅ **Background Transparent** quando cella selezionata  
✅ **BorderBrush Transparent** per rimuovere bordi visivi  
✅ **Foreground da SystemColors** per mantenere leggibilità  

## Implementazione

### Codice Applicato

```xaml
<DataGrid.CellStyle>
    <Style TargetType="{x:Type DataGridCell}">
        <Style.Triggers>
            <Trigger Property="DataGridCell.IsSelected" Value="True">
                <Setter Property="BorderBrush" Value="Transparent"/>
                <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
                <Setter Property="Background" Value="Transparent"/>
            </Trigger>
        </Style.Triggers>
    </Style>
</DataGrid.CellStyle>
```

### Cosa Cambia

| Prima (non funzionante) | Dopo (funzionante) |
|------------------------|--------------------|
| `DataGrid.RowStyle` con trigger `IsSelected` | `DataGrid.CellStyle` con trigger `DataGridCell.IsSelected` |
| Background azzurro visibile | Background completamente trasparente |
| Stile a livello di riga | Stile a livello di cella |

## Risultato

- ❌ **Nessun background azzurro** sulla riga/celle selezionate
- ✅ **Freccia `›` nella prima colonna** come unico indicatore visivo di selezione
- ✅ **Icone di azione completamente visibili** senza interferenze
- ✅ **Testo leggibile** con colore di sistema appropriato

## Files Modificati

- `src/PTRP.App/MainWindow.xaml` - Sostituisce RowStyle con CellStyle

## Testing

1. Compilare la soluzione
2. Eseguire l'applicazione
3. Cliccare su una riga del DataGrid
4. Verificare:
   - ✅ Nessun background azzurro visibile
   - ✅ Freccia `›` appare nella prima colonna
   - ✅ Icone Modifica/Elimina completamente visibili
   - ✅ Testo della riga leggibile

## Crediti

Soluzione fornita dall'utente dopo ricerca e test. Approccio corretto per WPF DataGrid.
