### PR TITLE
test: add missing model tests for ProfessionalEducator and TherapyProject

### DIFF
--- a/tests/PTRP.Tests/Models/ProfessionalEducatorModelTests.cs
+++ b/tests/PTRP.Tests/Models/ProfessionalEducatorModelTests.cs
@@ -1,0 +1,102 @@
+using PTRP.Models;
+
+namespace PTRP.Tests.Models;
+
+public class ProfessionalEducatorModelTests
+{
+    [Fact]
+    public void Constructor_SetsPropertiesCorrectly()
+    {
+        // Arrange & Act
+        var educator = new ProfessionalEducatorModel
+        {
+            Id = Guid.NewGuid(),
+            FirstName = "Mario",
+            LastName = "Rossi",
+            Email = "mario.rossi@example.com",
+            PhoneNumber = "+39 333 1234567",
+            DateOfBirth = new DateTime(1985, 5, 15),
+            Specialization = "Psicologia",
+            LicenseNumber = "PSY12345",
+            HireDate = DateTime.Now,
+            Status = "Active"
+        };
+
+        // Assert
+        Assert.NotEqual(Guid.Empty, educator.Id);
+        Assert.Equal("Mario", educator.FirstName);
+        Assert.Equal("Rossi", educator.LastName);
+        Assert.Equal("mario.rossi@example.com", educator.Email);
+        Assert.Equal("+39 333 1234567", educator.PhoneNumber);
+        Assert.Equal(new DateTime(1985, 5, 15), educator.DateOfBirth);
+        Assert.Equal("Psicologia", educator.Specialization);
+        Assert.Equal("PSY12345", educator.LicenseNumber);
+        Assert.NotEqual(default(DateTime), educator.HireDate);
+        Assert.Equal("Active", educator.Status);
+    }
+
+    [Fact]
+    public void ToString_ReturnsCorrectFormat()
+    {
+        // Arrange
+        var educator = new ProfessionalEducatorModel
+        {
+            FirstName = "Luigi",
+            LastName = "Bianchi",
+            Specialization = "Pedagogia"
+        };
+
+        // Act
+        var result = educator.ToString();
+
+        // Assert
+        Assert.Equal("Luigi Bianchi (Pedagogia)", result);
+    }
+
+    [Fact]
+    public void Status_DefaultsToActive()
+    {
+        // Arrange & Act
+        var educator = new ProfessionalEducatorModel
+        {
+            FirstName = "Test",
+            LastName = "User"
+        };
+
+        // Assert - default value should be "Active"
+        Assert.Equal("Active", educator.Status);
+    }
+
+    [Fact]
+    public void CreatedAt_IsSetAutomatically()
+    {
+        // Arrange
+        var beforeCreation = DateTime.Now.AddSeconds(-1);
+
+        // Act
+        var educator = new ProfessionalEducatorModel
+        {
+            FirstName = "Test",
+            LastName = "User"
+        };
+
+        // Assert
+        Assert.True(educator.CreatedAt >= beforeCreation);
+        Assert.Null(educator.UpdatedAt);
+    }
+
+    [Fact]
+    public void AssignedTherapyProjects_InitializesAsEmptyCollection()
+    {
+        // Arrange & Act
+        var educator = new ProfessionalEducatorModel
+        {
+            FirstName = "Test",
+            LastName = "User"
+        };
+
+        // Assert
+        Assert.NotNull(educator.AssignedTherapyProjects);
+        Assert.Empty(educator.AssignedTherapyProjects);
+    }
+}

--- a/tests/PTRP.Tests/Models/TherapyProjectModelTests.cs
+++ b/tests/PTRP.Tests/Models/TherapyProjectModelTests.cs
@@ -1,0 +1,140 @@
+using PTRP.Models;
+
+namespace PTRP.Tests.Models;
+
+public class TherapyProjectModelTests
+{
+    [Fact]
+    public void Constructor_SetsPropertiesCorrectly()
+    {
+        // Arrange & Act
+        var patientId = Guid.NewGuid();
+        var project = new TherapyProjectModel
+        {
+            Id = Guid.NewGuid(),
+            PatientId = patientId,
+            Title = "Progetto Terapeutico 2024",
+            Description = "Intervento educativo individualizzato",
+            StartDate = new DateTime(2024, 1, 15),
+            EndDate = new DateTime(2024, 12, 31),
+            Status = "In Progress"
+        };
+
+        // Assert
+        Assert.NotEqual(Guid.Empty, project.Id);
+        Assert.Equal(patientId, project.PatientId);
+        Assert.Equal("Progetto Terapeutico 2024", project.Title);
+        Assert.Equal("Intervento educativo individualizzato", project.Description);
+        Assert.Equal(new DateTime(2024, 1, 15), project.StartDate);
+        Assert.Equal(new DateTime(2024, 12, 31), project.EndDate);
+        Assert.Equal("In Progress", project.Status);
+    }
+
+    [Fact]
+    public void ToString_ReturnsCorrectFormat()
+    {
+        // Arrange
+        var patientId = Guid.NewGuid();
+        var project = new TherapyProjectModel
+        {
+            PatientId = patientId,
+            Title = "Test Project"
+        };
+
+        // Act
+        var result = project.ToString();
+
+        // Assert
+        Assert.Equal($"Test Project (Patient: {patientId})", result);
+    }
+
+    [Fact]
+    public void Status_HasDefaultValue()
+    {
+        // Arrange & Act
+        var project = new TherapyProjectModel
+        {
+            PatientId = Guid.NewGuid(),
+            Title = "Test"
+        };
+
+        // Assert - Check that Status can be set
+        Assert.NotNull(project.Status);
+    }
+
+    [Fact]
+    public void CreatedAt_IsSetAutomatically()
+    {
+        // Arrange
+        var beforeCreation = DateTime.Now.AddSeconds(-1);
+
+        // Act
+        var project = new TherapyProjectModel
+        {
+            PatientId = Guid.NewGuid(),
+            Title = "Test Project"
+        };
+
+        // Assert
+        Assert.True(project.CreatedAt >= beforeCreation);
+        Assert.Null(project.UpdatedAt);
+    }
+
+    [Fact]
+    public void Patient_CanBeNull()
+    {
+        // Arrange & Act
+        var project = new TherapyProjectModel
+        {
+            PatientId = Guid.NewGuid(),
+            Title = "Test"
+        };
+
+        // Assert - Patient navigation property can be null
+        Assert.Null(project.Patient);
+    }
+
+    [Fact]
+    public void EndDate_CanBeNull()
+    {
+        // Arrange & Act
+        var project = new TherapyProjectModel
+        {
+            PatientId = Guid.NewGuid(),
+            Title = "Ongoing Project",
+            StartDate = DateTime.Now
+        };
+
+        // Assert
+        Assert.Null(project.EndDate);
+    }
+
+    [Fact]
+    public void UpdatedAt_CanBeNull()
+    {
+        // Arrange & Act
+        var project = new TherapyProjectModel
+        {
+            PatientId = Guid.NewGuid(),
+            Title = "New Project"
+        };
+
+        // Assert
+        Assert.Null(project.UpdatedAt);
+    }
+
+    [Fact]
+    public void ProfessionalEducators_InitializesAsEmptyCollection()
+    {
+        // Arrange & Act
+        var project = new TherapyProjectModel
+        {
+            PatientId = Guid.NewGuid(),
+            Title = "Test Project"
+        };
+
+        // Assert
+        Assert.NotNull(project.ProfessionalEducators);
+        Assert.Empty(project.ProfessionalEducators);
+    }
+}

--- a/tests/PTRP.Tests/Models/TherapyProjectModelTests.cs
+++ b/tests/PTRP.Tests/Models/TherapyProjectModelTests.cs
@@ -38,14 +38,15 @@ public class TherapyProjectModelTests
         var project = new TherapyProjectModel
         {
             PatientId = patientId,
-            Title = "Test Project"
+            Title = "Test Project",
+            Status = "In Progress"
         };
 
         // Act
         var result = project.ToString();
 
-        // Assert
-        Assert.Equal($"Test Project (Patient: {patientId})", result);
+        // Assert - Format: "Title (Paziente: ID, Status: Status)"
+        Assert.Equal($"Test Project (Paziente: {patientId}, Status: In Progress)", result);
     }
 
     [Fact]
@@ -58,8 +59,8 @@ public class TherapyProjectModelTests
             Title = "Test"
         };
 
-        // Assert - Check that Status can be set
-        Assert.NotNull(project.Status);
+        // Assert - Default status should be "In Progress"
+        Assert.Equal("In Progress", project.Status);
     }
 
     [Fact]


### PR DESCRIPTION
## Descrizione

Aggiunta dei test model mancanti per `ProfessionalEducatorModel` e `TherapyProjectModel` per completare la copertura test dei modelli di dominio.

## Tipo di Modifica

- [x] 🧪 Test (aggiunta test)

## Problema

Durante la review della test suite, abbiamo identificato che mancavano i test model per:
- ProfessionalEducator (5 test)
- TherapyProject (8 test)

Questi test sono necessari per:
1. Completare la copertura test dei modelli
2. Validare il comportamento dei costruttori e proprietà
3. Verificare default values e ToString formatting
4. Assicurare consistenza con PatientModelTests esistente

## Modifiche Apportate

### 🧪 ProfessionalEducatorModelTests (5 test)

1. `Constructor_SetsPropertiesCorrectly` - Verifica inizializzazione proprietà
2. `ToString_ReturnsCorrectFormat` - Verifica format "FirstName LastName (Specialization)"
3. `Status_DefaultsToActive` - Verifica default value "Active"
4. `CreatedAt_IsSetAutomatically` - Verifica timestamp creazione
5. `AssignedTherapyProjects_InitializesAsEmptyCollection` - Verifica collection initialization

### 🧪 TherapyProjectModelTests (8 test)

1. `Constructor_SetsPropertiesCorrectly` - Verifica inizializzazione proprietà
2. `ToString_ReturnsCorrectFormat` - Verifica format "Title (Patient: ID)"
3. `Status_HasDefaultValue` - Verifica default status
4. `CreatedAt_IsSetAutomatically` - Verifica timestamp creazione
5. `Patient_CanBeNull` - Verifica navigation property nullable
6. `EndDate_CanBeNull` - Verifica nullable EndDate
7. `UpdatedAt_CanBeNull` - Verifica nullable UpdatedAt
8. `ProfessionalEducators_InitializesAsEmptyCollection` - Verifica collection initialization

## 📊 Metriche Test

**Prima**:
- Model tests: 3 (solo Patient)

**Dopo**:
- Model tests: **16** (Patient 3 + Educator 5 + TherapyProject 8)

**Totale test suite**: ~135 test
- Model: 16
- Repository: 64 (Patient 21 + Educator 23 + TherapyProject 20)
- Service: 42 (Educator 20 + TherapyProject 22)

## ✅ Checklist

- [x] Test seguono convenzioni PatientModelTests
- [x] Coverage per tutti i modelli di dominio
- [x] Verifica default values
- [x] Verifica ToString format
- [x] Verifica collection initialization
- [x] Verifica nullable properties
- [x] Verifica CreatedAt/UpdatedAt

## 🔗 Relazioni

- Completa: Issue #12 (Educator model tests)
- Completa: Issue #11 (TherapyProject model tests)  
- Dipende da: #9 (Models implementati)

## 📝 Note

- Questi test erano stati menzionati come mancanti nella review
- Seguono esattamente lo stesso pattern di PatientModelTests
- Nessuna dipendenza esterna (pure unit test)
- Fix atteso per fallimento test CI
