### PR TITLE
fix: return empty collection for empty search term in PatientRepository

### DIFF
--- a/src/PTRP.Data/Repositories/PatientRepository.cs
+++ b/src/PTRP.Data/Repositories/PatientRepository.cs
@@ -48,9 +48,7 @@ public class PatientRepository : IPatientRepository
     public async Task<IEnumerable<PatientModel>> SearchAsync(string searchTerm)
     {
         if (string.IsNullOrWhiteSpace(searchTerm))
-        {
-            return await GetAllAsync();
-        }
+            return Enumerable.Empty<PatientModel>();
 
         var normalizedSearchTerm = searchTerm.Trim().ToLower();
 


### PR DESCRIPTION
## Descrizione

Fix del comportamento del metodo `SearchAsync` in `PatientRepository` per allinearlo agli altri repository (Educator e TherapyProject).

## Tipo di Modifica

- [x] 🐛 Bug fix (modifica non breaking che risolve un problema)

## Problema

Il test `PatientRepositoryTests.SearchAsync_EmptyTerm_ReturnsEmpty` falliva perché l'implementazione del metodo `SearchAsync` restituiva **tutti i pazienti** quando il termine di ricerca era vuoto o whitespace, invece di restituire una **collection vuota**.

### Error Log
```
Failed PTRP.Tests.Repositories.PatientRepositoryTests.SearchAsync_EmptyTerm_ReturnsEmpty
Assert.Empty() Failure: Collection was not empty
Collection: [Test Patient]
```

### Root Cause

**Prima (comportamento errato)**:
```csharp
if (string.IsNullOrWhiteSpace(searchTerm))
{
    return await GetAllAsync();  // ❌ Restituiva TUTTI i pazienti
}
```

Questo comportamento era **inconsistente** con gli altri repository:

**EducatorRepository.SearchAsync** (comportamento corretto):
```csharp
if (string.IsNullOrWhiteSpace(searchTerm))
    return Enumerable.Empty<ProfessionalEducatorModel>();
```

**TherapyProjectRepository.SearchAsync** (comportamento corretto):
```csharp
if (string.IsNullOrWhiteSpace(searchTerm))
    return Enumerable.Empty<TherapyProjectModel>();
```

## Modifiche Apportate

### Fix Applicato [commit 8b32889](https://github.com/artcava/PTRP/commit/8b32889f9eb319a15852996d9abb9104be18132c)

**Dopo (comportamento corretto)**:
```csharp
if (string.IsNullOrWhiteSpace(searchTerm))
    return Enumerable.Empty<PatientModel>();
```

## 🎯 Razionale

### Perché Empty Collection?

1. **Consistenza**: Tutti e tre i repository (Patient, Educator, TherapyProject) devono avere lo stesso comportamento
2. **Semantica**: Un termine di ricerca vuoto significa "nessun criterio di ricerca" → nessun risultato
3. **UX**: Se l'utente vuole vedere tutti i risultati, usa `GetAllAsync()`, non `SearchAsync("")`
4. **Performance**: Evita query non necessarie quando non c'è un termine valido
5. **Security**: Previene query accidentali che potrebbero restituire grandi dataset

## ✅ Test Verificati

Il fix risolve il test fallito:
- ✅ `SearchAsync_EmptyTerm_ReturnsEmpty` - Ora passa correttamente

Altri test di ricerca continuano a funzionare:
- ✅ `SearchAsync_FindsByFirstName`
- ✅ `SearchAsync_FindsByLastName`
- ✅ `SearchAsync_IsCaseInsensitive`
- ✅ `SearchAsync_NoMatch_ReturnsEmpty`

## 📊 Impatto

- **Breaking**: No - comportamento edge case che non dovrebbe essere usato in produzione
- **Repository layer**: Solo `PatientRepository.SearchAsync`
- **Test**: Fix test `SearchAsync_EmptyTerm_ReturnsEmpty`
- **Consistenza**: Ora tutti i repository hanno comportamento uniforme

## ✅ Checklist

- [x] Fix allineato a EducatorRepository e TherapyProjectRepository
- [x] Comportamento consistente tra tutti i repository
- [x] Test `SearchAsync_EmptyTerm_ReturnsEmpty` passa
- [x] Nessun impatto su altri test
- [x] Nessuna modifica breaking
- [x] Commit message descrittivo

## 🔗 Relazioni

- Blocca: PR #35 (PatientRepository tests)
- Fix per: Test failure in CI/CD

## 📝 Note

Questa è una modifica minor ma importante per:
1. Consistenza del codebase
2. Comportamento prevedibile delle API
3. Allineamento con le best practices degli altri repository

Dopo il merge di questa PR, la PR #35 dovrebbe passare tutti i test.
