### PR TITLE
feat: Implement ProjectListView with Master-Detail layout (Issue #64)

### DIFF
--- a/src/PTRP.App/App.xaml
+++ b/src/PTRP.App/App.xaml
@@ -5,8 +5,10 @@
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:viewmodels="clr-namespace:PTRP.ViewModels;assembly=PTRP.ViewModels"
              xmlns:educatorViewModels="clr-namespace:PTRP.ViewModels.Educators;assembly=PTRP.ViewModels"
+             xmlns:projectViewModels="clr-namespace:PTRP.ViewModels.Projects;assembly=PTRP.ViewModels"
              xmlns:patientViews="clr-namespace:PTRP.App.Views.Patients"
              xmlns:educatorViews="clr-namespace:PTRP.App.Views.Educators"
+             xmlns:projectViews="clr-namespace:PTRP.App.Views.Projects"
              xmlns:converters="clr-namespace:PTRP.App.Converters">
     <Application.Resources>
         <ResourceDictionary>
@@ -37,6 +39,11 @@
             <!-- Issue #63: Educator List View -->
             <DataTemplate DataType="{x:Type educatorViewModels:EducatorListViewModel}">
                 <educatorViews:EducatorListView />
+            </DataTemplate>
+            
+            <!-- Issue #64: Project List View -->
+            <DataTemplate DataType="{x:Type projectViewModels:ProjectListViewModel}">
+                <projectViews:ProjectListView />
             </DataTemplate>
             
             <!-- Future DataTemplates will be added here as other issues are implemented -->

--- a/src/PTRP.App/App.xaml.cs
+++ b/src/PTRP.App/App.xaml.cs
@@ -4,11 +4,13 @@ using PTRP.Services;
 using PTRP.Services.Interfaces;
 using PTRP.ViewModels;
 using PTRP.ViewModels.Educators;
+using PTRP.ViewModels.Projects;
 using PTRP.Data;
 using PTRP.Data.Repositories;
 using PTRP.Data.Repositories.Interfaces;
 using PTRP.App.Views.Patients;
 using PTRP.App.Views.Educators;
+using PTRP.App.Views.Projects;
 using System.IO;
 using System.Windows;
 
@@ -113,6 +115,7 @@ namespace PTRP.App
             // services.AddTransient<DashboardViewModel>();  // Issue #50: Dashboard ViewModel
             services.AddTransient<PatientListViewModel>(); // Issue #51: Patient List ViewModel
             services.AddTransient<EducatorListViewModel>(); // Issue #63: Educator List ViewModel
+            services.AddTransient<ProjectListViewModel>(); // Issue #64: Project List ViewModel
             // TODO: Registrare qui i ViewModels delle pagine quando verranno creati
             // services.AddTransient<SyncViewModel>();        // Issue #52
 
@@ -120,6 +123,7 @@ namespace PTRP.App
             services.AddScoped<MainWindow>();
             services.AddScoped<PatientListView>();  // Issue #51: Patient List View
             services.AddScoped<EducatorListView>();  // Issue #63: Educator List View
+            services.AddScoped<ProjectListView>();  // Issue #64: Project List View
         }
 
         /// <summary>

--- a/src/PTRP.App/Views/Projects/ProjectListView.xaml
+++ b/src/PTRP.App/Views/Projects/ProjectListView.xaml
@@ -1,0 +1,225 @@
+<UserControl x:Class="PTRP.App.Views.Projects.ProjectListView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             mc:Ignorable="d" 
+             d:DesignHeight="600" d:DesignWidth="1200">
+    <Grid Margin="16">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="2*"/>
+            <ColumnDefinition Width="16"/>
+            <ColumnDefinition Width="1*"/>
+        </Grid.ColumnDefinitions>
+
+        <materialDesign:Card Grid.Column="0">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <Border Grid.Row="0" Background="{DynamicResource PrimaryHueMidBrush}" Padding="16">
+                    <TextBlock Text="Lista Progetti" Style="{StaticResource MaterialDesignHeadline6TextBlock}" Foreground="White"/>
+                </Border>
+
+                <StackPanel Grid.Row="1" Margin="16">
+                    <TextBox materialDesign:HintAssist.Hint="🔍 Cerca per titolo o paziente"
+                             Text="{Binding SearchTerm, UpdateSourceTrigger=PropertyChanged}"
+                             Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                             Margin="0,0,0,8" />
+                    <ComboBox materialDesign:HintAssist.Hint="Filtra per stato"
+                              ItemsSource="{Binding StateFilters}"
+                              SelectedItem="{Binding SelectedStateFilter}"
+                              Style="{StaticResource MaterialDesignOutlinedComboBox}"/>
+                </StackPanel>
+
+                <DataGrid Grid.Row="2"
+                          ItemsSource="{Binding Projects}"
+                          SelectedItem="{Binding SelectedProject}"
+                          AutoGenerateColumns="False"
+                          IsReadOnly="True"
+                          SelectionMode="Single"
+                          CanUserAddRows="False"
+                          CanUserDeleteRows="False"
+                          CanUserResizeRows="False"
+                          HeadersVisibility="Column"
+                          GridLinesVisibility="Horizontal"
+                          Margin="16,0,16,16">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="Titolo" Binding="{Binding Title}" Width="*"/>
+                        <DataGridTextColumn Header="Paziente" Binding="{Binding Patient.FullName}" Width="*"/>
+                        <DataGridTextColumn Header="Periodo" Binding="{Binding PeriodShort}" Width="Auto"/>
+                        <DataGridTemplateColumn Header="Stato" Width="Auto">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <Border Background="{Binding State, Converter={StaticResource ProjectStateToColorConverter}}" CornerRadius="12" Padding="8,4" HorizontalAlignment="Center">
+                                        <TextBlock Text="{Binding StateDisplay}" Foreground="White" FontSize="11" FontWeight="SemiBold"/>
+                                    </Border>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                        <DataGridTextColumn Header="Educatori" Binding="{Binding EducatorCount}" Width="Auto"/>
+                    </DataGrid.Columns>
+                </DataGrid>
+            </Grid>
+        </materialDesign:Card>
+
+        <materialDesign:Card Grid.Column="2" Visibility="{Binding SelectedProject, Converter={StaticResource NullToVisibilityConverter}}">
+            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <StackPanel Margin="16">
+                    <Grid Margin="0,0,0,16">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="{Binding SelectedProject.Title}" Style="{StaticResource MaterialDesignHeadline5TextBlock}" TextWrapping="Wrap"/>
+                        <StackPanel Grid.Column="1" Orientation="Horizontal">
+                            <Button ToolTip="Modifica" Style="{StaticResource MaterialDesignIconButton}" Margin="0,0,4,0">
+                                <materialDesign:PackIcon Kind="Pencil" Width="20" Height="20"/>
+                            </Button>
+                            <Button ToolTip="Sospendi" Style="{StaticResource MaterialDesignIconButton}" Margin="0,0,4,0">
+                                <materialDesign:PackIcon Kind="Pause" Width="20" Height="20"/>
+                            </Button>
+                            <Button ToolTip="Completa" Style="{StaticResource MaterialDesignIconButton}">
+                                <materialDesign:PackIcon Kind="Check" Width="20" Height="20"/>
+                            </Button>
+                        </StackPanel>
+                    </Grid>
+                    
+                    <TextBlock Text="Info Progetto" Style="{StaticResource MaterialDesignSubtitle1TextBlock}" Margin="0,0,0,8"/>
+                    <Border Background="{DynamicResource MaterialDesignDivider}" CornerRadius="4" Padding="12" Margin="0,0,0,16">
+                        <StackPanel>
+                            <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+                                <TextBlock Text="Periodo: " FontWeight="SemiBold"/>
+                                <TextBlock Text="{Binding SelectedProject.Period}"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+                                <TextBlock Text="Stato: " FontWeight="SemiBold"/>
+                                <TextBlock Text="{Binding SelectedProject.StateDisplay}"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
+                                <TextBlock Text="Creato il: " FontWeight="SemiBold"/>
+                                <TextBlock Text="{Binding SelectedProject.CreatedAt, StringFormat=dd/MM/yyyy}"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" Visibility="{Binding SelectedProject.SuspendedAt, Converter={StaticResource NullToVisibilityConverter}}" Margin="0,0,0,6">
+                                <TextBlock Text="Sospeso il: " FontWeight="SemiBold"/>
+                                <TextBlock Text="{Binding SelectedProject.SuspendedAt, StringFormat=dd/MM/yyyy}"/>
+                            </StackPanel>
+                            <TextBlock Text="{Binding SelectedProject.SuspensionReason}" TextWrapping="Wrap" FontStyle="Italic" Visibility="{Binding SelectedProject.SuspensionReason, Converter={StaticResource NullToVisibilityConverter}}" Margin="0,0,0,6"/>
+                            <StackPanel Orientation="Horizontal" Visibility="{Binding SelectedProject.CompletedAt, Converter={StaticResource NullToVisibilityConverter}}">
+                                <TextBlock Text="Completato il: " FontWeight="SemiBold"/>
+                                <TextBlock Text="{Binding SelectedProject.CompletedAt, StringFormat=dd/MM/yyyy}"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </Border>
+                    
+                    <TextBlock Text="Paziente" Style="{StaticResource MaterialDesignSubtitle1TextBlock}" Margin="0,0,0,8"/>
+                    <Border Background="{DynamicResource MaterialDesignDivider}" CornerRadius="4" Padding="12" Margin="0,0,0,16">
+                        <StackPanel>
+                            <TextBlock Text="{Binding SelectedProject.Patient.FullName}" FontWeight="SemiBold" FontSize="14" Margin="0,0,0,4"/>
+                            <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                                <TextBlock Text="Età: " FontWeight="SemiBold"/>
+                                <TextBlock Text="{Binding SelectedProject.Patient.Age}"/>
+                                <TextBlock Text=" anni"/>
+                            </StackPanel>
+                            <Button Style="{StaticResource MaterialDesignOutlinedButton}" HorizontalAlignment="Left">
+                                <StackPanel Orientation="Horizontal">
+                                    <materialDesign:PackIcon Kind="AccountDetails" Width="16" Height="16" Margin="0,0,6,0"/>
+                                    <TextBlock Text="Visualizza Scheda"/>
+                                </StackPanel>
+                            </Button>
+                        </StackPanel>
+                    </Border>
+                    
+                    <TextBlock Text="Educatori Assegnati" Style="{StaticResource MaterialDesignSubtitle1TextBlock}" Margin="0,0,0,8"/>
+                    <ItemsControl ItemsSource="{Binding SelectedProject.Educators}" Margin="0,0,0,16">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Background="{DynamicResource MaterialDesignDivider}" CornerRadius="4" Padding="12" Margin="0,0,0,8">
+                                    <StackPanel Orientation="Horizontal">
+                                        <Border Background="{DynamicResource PrimaryHueMidBrush}" CornerRadius="20" Width="36" Height="36" Margin="0,0,12,0">
+                                            <TextBlock Text="{Binding Initials}" Foreground="White" FontWeight="SemiBold" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                        </Border>
+                                        <TextBlock Text="{Binding FullName}" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                    
+                    <TextBlock Text="Progresso Visite" Style="{StaticResource MaterialDesignSubtitle1TextBlock}" Margin="0,0,0,8"/>
+                    <Border Background="{DynamicResource MaterialDesignDivider}" CornerRadius="4" Padding="12" Margin="0,0,0,16">
+                        <StackPanel>
+                            <TextBlock Text="{Binding SelectedProject.ProgressDisplay}" FontWeight="SemiBold" HorizontalAlignment="Center" Margin="0,0,0,8"/>
+                            <ProgressBar Value="{Binding SelectedProject.ProgressPercentage}" Maximum="100" Height="8" Style="{StaticResource MaterialDesignLinearProgressBar}"/>
+                            <TextBlock Text="{Binding SelectedProject.ProgressPercentage, StringFormat={}{0:F0}%}" HorizontalAlignment="Center" FontSize="12" Margin="0,4,0,0"/>
+                        </StackPanel>
+                    </Border>
+                    
+                    <TextBlock Text="Timeline Appuntamenti" Style="{StaticResource MaterialDesignSubtitle1TextBlock}" Margin="0,0,0,8"/>
+                    <ItemsControl ItemsSource="{Binding SelectedProject.Appointments}" Margin="0,0,0,16">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Background="{DynamicResource MaterialDesignDivider}" CornerRadius="4" Padding="12" Margin="0,0,0,8">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="*"/>
+                                        </Grid.ColumnDefinitions>
+                                        <materialDesign:PackIcon Kind="CheckCircle" Width="20" Height="20" VerticalAlignment="Top" Margin="0,0,12,0" Foreground="{DynamicResource PrimaryHueMidBrush}">
+                                            <materialDesign:PackIcon.Style>
+                                                <Style TargetType="materialDesign:PackIcon">
+                                                    <Setter Property="Kind" Value="CalendarClock"/>
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding IsCompleted}" Value="True">
+                                                            <Setter Property="Kind" Value="CheckCircle"/>
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </materialDesign:PackIcon.Style>
+                                        </materialDesign:PackIcon>
+                                        <StackPanel Grid.Column="1">
+                                            <TextBlock Text="{Binding TypeDisplay}" FontWeight="SemiBold" FontSize="14"/>
+                                            <TextBlock Text="{Binding FormattedDate}" FontSize="12" Foreground="{DynamicResource MaterialDesignBodyLight}" Margin="0,2,0,0"/>
+                                            <TextBlock Text="{Binding Location}" FontSize="12" Foreground="{DynamicResource MaterialDesignBodyLight}" Margin="0,2,0,0"/>
+                                            <TextBlock Text="{Binding StatusDisplay}" FontSize="12" FontStyle="Italic" Margin="0,2,0,0">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock">
+                                                        <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBodyLight}"/>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding IsCompleted}" Value="True">
+                                                                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}"/>
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
+                                        </StackPanel>
+                                    </Grid>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                    
+                    <StackPanel>
+                        <Button Style="{StaticResource MaterialDesignRaisedButton}" HorizontalAlignment="Stretch" Margin="0,0,0,8">
+                            <StackPanel Orientation="Horizontal">
+                                <materialDesign:PackIcon Kind="CalendarPlus" Width="20" Height="20" Margin="0,0,8,0"/>
+                                <TextBlock Text="Nuovo Appuntamento"/>
+                            </StackPanel>
+                        </Button>
+                        <Button Style="{StaticResource MaterialDesignOutlinedButton}" HorizontalAlignment="Stretch">
+                            <StackPanel Orientation="Horizontal">
+                                <materialDesign:PackIcon Kind="FileDocument" Width="20" Height="20" Margin="0,0,8,0"/>
+                                <TextBlock Text="Storico Visite"/>
+                            </StackPanel>
+                        </Button>
+                    </StackPanel>
+                </StackPanel>
+            </ScrollViewer>
+        </materialDesign:Card>
+    </Grid>
+</UserControl>

--- a/src/PTRP.App/Views/Projects/ProjectListView.xaml
+++ b/src/PTRP.App/Views/Projects/ProjectListView.xaml
@@ -154,7 +154,7 @@
                     <Border Background="{DynamicResource MaterialDesignDivider}" CornerRadius="4" Padding="12" Margin="0,0,0,16">
                         <StackPanel>
                             <TextBlock Text="{Binding SelectedProject.ProgressDisplay}" FontWeight="SemiBold" HorizontalAlignment="Center" Margin="0,0,0,8"/>
-                            <ProgressBar Value="{Binding SelectedProject.ProgressPercentage}" Maximum="100" Height="8" Style="{StaticResource MaterialDesignLinearProgressBar}"/>
+                            <ProgressBar Value="{Binding SelectedProject.ProgressPercentage, Mode=OneWay}" Maximum="100" Height="8" Style="{StaticResource MaterialDesignLinearProgressBar}"/>
                             <TextBlock Text="{Binding SelectedProject.ProgressPercentage, StringFormat={}{0:F0}%}" HorizontalAlignment="Center" FontSize="12" Margin="0,4,0,0"/>
                         </StackPanel>
                     </Border>

--- a/src/PTRP.App/Views/Projects/ProjectListView.xaml.cs
+++ b/src/PTRP.App/Views/Projects/ProjectListView.xaml.cs
@@ -1,0 +1,15 @@
+using System.Windows.Controls;
+
+namespace PTRP.App.Views.Projects
+{
+    /// <summary>
+    /// Interaction logic for ProjectListView.xaml
+    /// </summary>
+    public partial class ProjectListView : UserControl
+    {
+        public ProjectListView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/PTRP.ViewModels/MainViewModel.cs
+++ b/src/PTRP.ViewModels/MainViewModel.cs
@@ -8,6 +8,7 @@ using CommunityToolkit.Mvvm.Input;
 using MaterialDesignThemes.Wpf;
 using PTRP.Services.Interfaces;
 using PTRP.ViewModels.Educators;
+using PTRP.ViewModels.Projects;
 
 namespace PTRP.ViewModels;
 
@@ -216,7 +217,7 @@ public partial class MainViewModel : ViewModelBase
             {
                 Title = "Progetti",
                 IconKind = PackIconKind.FolderMultiple,
-                // ViewModelType = typeof(ProjectListViewModel) // TODO: FASE 2
+                ViewModelType = typeof(ProjectListViewModel) // Issue #64: IMPLEMENTED
             },
             new MenuItemViewModel
             {
@@ -293,6 +294,11 @@ public partial class MainViewModel : ViewModelBase
         else if (viewModel is EducatorListViewModel educatorListViewModel)
         {
             await educatorListViewModel.LoadEducatorsAsync();
+        }
+        // Issue #64: Load projects when navigating to ProjectListView
+        else if (viewModel is ProjectListViewModel projectListViewModel)
+        {
+            await projectListViewModel.LoadProjectsAsync();
         }
         // TODO: Issue #50 - Uncomment when DashboardViewModel is implemented
         // else if (viewModel is DashboardViewModel dashboardViewModel)
@@ -570,8 +576,8 @@ public partial class MainViewModel : ViewModelBase
     [RelayCommand]
     private void NavigateToProjects()
     {
-        ShowInfo("Progetti - In sviluppo (FASE 2)");
-        CurrentPageTitle = "Progetti";
+        // Issue #64: ProjectListViewModel implementato
+        _navigationService.NavigateTo<ProjectListViewModel>();
     }
     
     [RelayCommand]

--- a/src/PTRP.ViewModels/Projects/ProjectAppointmentViewModel.cs
+++ b/src/PTRP.ViewModels/Projects/ProjectAppointmentViewModel.cs
@@ -1,0 +1,55 @@
+using System;
+
+namespace PTRP.ViewModels.Projects;
+
+/// <summary>
+/// ViewModel per rappresentare un appuntamento/visita collegato a un progetto.
+/// Utilizzato nella timeline appuntamenti nel detail panel progetto.
+/// </summary>
+public class ProjectAppointmentViewModel
+{
+    /// <summary>
+    /// ID univoco dell'appuntamento.
+    /// </summary>
+    public Guid AppointmentId { get; set; }
+
+    /// <summary>
+    /// Tipo di appuntamento.
+    /// </summary>
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Descrizione del tipo per visualizzazione.
+    /// </summary>
+    public string TypeDisplay { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Data e ora programmata dell'appuntamento.
+    /// </summary>
+    public DateTime ScheduledDate { get; set; }
+
+    /// <summary>
+    /// Data formattata per visualizzazione.
+    /// </summary>
+    public string FormattedDate => ScheduledDate.ToString("dd/MM/yyyy HH:mm");
+
+    /// <summary>
+    /// Indica se l'appuntamento è stato completato.
+    /// </summary>
+    public bool IsCompleted { get; set; }
+
+    /// <summary>
+    /// Data di completamento (se completato).
+    /// </summary>
+    public DateTime? CompletedDate { get; set; }
+
+    /// <summary>
+    /// Luogo dell'appuntamento.
+    /// </summary>
+    public string Location { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Stato formattato per visualizzazione.
+    /// </summary>
+    public string StatusDisplay => IsCompleted ? "Completata" : "Programmata";
+}

--- a/src/PTRP.ViewModels/Projects/ProjectEducatorViewModel.cs
+++ b/src/PTRP.ViewModels/Projects/ProjectEducatorViewModel.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace PTRP.ViewModels.Projects;
+
+/// <summary>
+/// ViewModel per rappresentare un educatore assegnato a un progetto.
+/// Utilizzato nella lista educatori nel detail panel del progetto.
+/// </summary>
+public class ProjectEducatorViewModel
+{
+    /// <summary>
+    /// ID univoco dell'educatore.
+    /// </summary>
+    public Guid EducatorId { get; set; }
+
+    /// <summary>
+    /// Nome dell'educatore.
+    /// </summary>
+    public string FirstName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Cognome dell'educatore.
+    /// </summary>
+    public string LastName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Nome completo (Nome + Cognome).
+    /// </summary>
+    public string FullName => $"{FirstName} {LastName}";
+
+    /// <summary>
+    /// Iniziali dell'educatore (es: "MB" per Mario Bianchi).
+    /// </summary>
+    public string Initials { get; set; } = string.Empty;
+}

--- a/src/PTRP.ViewModels/Projects/ProjectListViewModel.cs
+++ b/src/PTRP.ViewModels/Projects/ProjectListViewModel.cs
@@ -1,0 +1,591 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace PTRP.ViewModels.Projects;
+
+/// <summary>
+/// ViewModel principale per la vista lista progetti.
+/// Gestisce il caricamento, la ricerca e la selezione dei progetti.
+/// </summary>
+public partial class ProjectListViewModel : ViewModelBase
+{
+    [ObservableProperty]
+    private string _searchTerm = string.Empty;
+
+    [ObservableProperty]
+    private string _selectedStateFilter = "Tutti";
+
+    [ObservableProperty]
+    private ObservableCollection<string> _stateFilters = new()
+    {
+        "Tutti",
+        "Active",
+        "Suspended",
+        "Completed",
+        "Deceased"
+    };
+
+    [ObservableProperty]
+    private ObservableCollection<ProjectViewModel> _projects = new();
+
+    private List<ProjectViewModel> _allProjects = new();
+
+    [ObservableProperty]
+    private ProjectViewModel? _selectedProject;
+
+    [ObservableProperty]
+    private bool _isLoading;
+
+    public override string DisplayName => "Progetti";
+
+    /// <summary>
+    /// Carica la lista di progetti.
+    /// TODO: Sostituire con IProjectService.GetAllAsync() quando disponibile.
+    /// </summary>
+    public async Task LoadProjectsAsync()
+    {
+        IsLoading = true;
+        try
+        {
+            await Task.Delay(500); // Simula chiamata API
+            _allProjects = GenerateSampleProjects();
+            ApplyFilters();
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    /// <summary>
+    /// Applica i filtri di ricerca e stato alla lista progetti.
+    /// </summary>
+    private void ApplyFilters()
+    {
+        var query = _allProjects.AsEnumerable();
+
+        // Filtro ricerca (Title, Patient name)
+        if (!string.IsNullOrWhiteSpace(SearchTerm))
+        {
+            query = query.Where(p =>
+                p.Title.Contains(SearchTerm, StringComparison.OrdinalIgnoreCase) ||
+                p.Patient.FullName.Contains(SearchTerm, StringComparison.OrdinalIgnoreCase));
+        }
+
+        // Filtro stato
+        if (SelectedStateFilter != "Tutti")
+        {
+            query = query.Where(p => p.State == SelectedStateFilter);
+        }
+
+        Projects = new ObservableCollection<ProjectViewModel>(query);
+    }
+
+    /// <summary>
+    /// Genera progetti di test con dati realistici.
+    /// </summary>
+    private List<ProjectViewModel> GenerateSampleProjects()
+    {
+        return new List<ProjectViewModel>
+        {
+            new ProjectViewModel
+            {
+                Id = Guid.NewGuid(),
+                Title = "PTRP 2025-2027",
+                Description = "Progetto triennale per supporto autonomia e integrazione sociale",
+                StartDate = new DateTime(2025, 1, 15),
+                EndDate = new DateTime(2027, 12, 31),
+                State = "Active",
+                CreatedAt = new DateTime(2025, 1, 10),
+                Patient = new ProjectPatientViewModel
+                {
+                    PatientId = Guid.NewGuid(),
+                    FirstName = "Mario",
+                    LastName = "Rossi",
+                    BirthDate = new DateTime(1990, 5, 20)
+                },
+                Educators = new List<ProjectEducatorViewModel>
+                {
+                    new ProjectEducatorViewModel
+                    {
+                        EducatorId = Guid.NewGuid(),
+                        FirstName = "Mario",
+                        LastName = "Bianchi",
+                        Initials = "MB"
+                    },
+                    new ProjectEducatorViewModel
+                    {
+                        EducatorId = Guid.NewGuid(),
+                        FirstName = "Laura",
+                        LastName = "Verdi",
+                        Initials = "LV"
+                    }
+                },
+                Appointments = new List<ProjectAppointmentViewModel>
+                {
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "PrimaApertura",
+                        TypeDisplay = "Prima Apertura",
+                        ScheduledDate = new DateTime(2025, 2, 5, 14, 30, 0),
+                        IsCompleted = true,
+                        CompletedDate = new DateTime(2025, 2, 5, 15, 45, 0),
+                        Location = "Centro Diurno"
+                    },
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "Intermedia",
+                        TypeDisplay = "Visita Intermedia",
+                        ScheduledDate = new DateTime(2025, 3, 15, 10, 0, 0),
+                        IsCompleted = true,
+                        CompletedDate = new DateTime(2025, 3, 15, 11, 30, 0),
+                        Location = "Ambulatorio"
+                    },
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "Intermedia",
+                        TypeDisplay = "Visita Intermedia",
+                        ScheduledDate = new DateTime(2025, 4, 2, 14, 30, 0),
+                        IsCompleted = false,
+                        Location = "Centro Diurno"
+                    },
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "Intermedia",
+                        TypeDisplay = "Visita Intermedia",
+                        ScheduledDate = new DateTime(2025, 6, 10, 9, 0, 0),
+                        IsCompleted = false,
+                        Location = "Centro Diurno"
+                    },
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "Finale",
+                        TypeDisplay = "Visita Finale",
+                        ScheduledDate = new DateTime(2027, 12, 20, 15, 0, 0),
+                        IsCompleted = false,
+                        Location = "Centro Diurno"
+                    }
+                }
+            },
+            new ProjectViewModel
+            {
+                Id = Guid.NewGuid(),
+                Title = "PTRP 2024-2026",
+                Description = "Progetto biennale per sviluppo abilità lavorative",
+                StartDate = new DateTime(2024, 9, 1),
+                EndDate = new DateTime(2026, 8, 31),
+                State = "Active",
+                CreatedAt = new DateTime(2024, 8, 20),
+                Patient = new ProjectPatientViewModel
+                {
+                    PatientId = Guid.NewGuid(),
+                    FirstName = "Luca",
+                    LastName = "Bianchi",
+                    BirthDate = new DateTime(1985, 11, 10)
+                },
+                Educators = new List<ProjectEducatorViewModel>
+                {
+                    new ProjectEducatorViewModel
+                    {
+                        EducatorId = Guid.NewGuid(),
+                        FirstName = "Giovanni",
+                        LastName = "Rossi",
+                        Initials = "GR"
+                    }
+                },
+                Appointments = new List<ProjectAppointmentViewModel>
+                {
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "PrimaApertura",
+                        TypeDisplay = "Prima Apertura",
+                        ScheduledDate = new DateTime(2024, 9, 10, 14, 0, 0),
+                        IsCompleted = true,
+                        CompletedDate = new DateTime(2024, 9, 10, 15, 30, 0),
+                        Location = "Centro Diurno"
+                    },
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "Intermedia",
+                        TypeDisplay = "Visita Intermedia",
+                        ScheduledDate = new DateTime(2024, 12, 5, 10, 30, 0),
+                        IsCompleted = true,
+                        CompletedDate = new DateTime(2024, 12, 5, 11, 45, 0),
+                        Location = "Ambulatorio"
+                    },
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "Intermedia",
+                        TypeDisplay = "Visita Intermedia",
+                        ScheduledDate = new DateTime(2025, 3, 20, 9, 0, 0),
+                        IsCompleted = true,
+                        CompletedDate = new DateTime(2025, 3, 20, 10, 15, 0),
+                        Location = "Centro Diurno"
+                    },
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "Finale",
+                        TypeDisplay = "Visita Finale",
+                        ScheduledDate = new DateTime(2025, 5, 15, 10, 0, 0),
+                        IsCompleted = false,
+                        Location = "Ambulatorio"
+                    }
+                }
+            },
+            new ProjectViewModel
+            {
+                Id = Guid.NewGuid(),
+                Title = "PTRP 2023-2025",
+                Description = "Progetto per supporto abitativo e autonomia personale",
+                StartDate = new DateTime(2023, 3, 1),
+                EndDate = new DateTime(2025, 2, 28),
+                State = "Suspended",
+                CreatedAt = new DateTime(2023, 2, 15),
+                SuspendedAt = new DateTime(2025, 1, 15),
+                SuspensionReason = "Ricovero ospedaliero del paziente",
+                Patient = new ProjectPatientViewModel
+                {
+                    PatientId = Guid.NewGuid(),
+                    FirstName = "Anna",
+                    LastName = "Verdi",
+                    BirthDate = new DateTime(1992, 7, 3)
+                },
+                Educators = new List<ProjectEducatorViewModel>
+                {
+                    new ProjectEducatorViewModel
+                    {
+                        EducatorId = Guid.NewGuid(),
+                        FirstName = "Laura",
+                        LastName = "Verdi",
+                        Initials = "LV"
+                    }
+                },
+                Appointments = new List<ProjectAppointmentViewModel>
+                {
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "PrimaApertura",
+                        TypeDisplay = "Prima Apertura",
+                        ScheduledDate = new DateTime(2023, 3, 10, 14, 30, 0),
+                        IsCompleted = true,
+                        CompletedDate = new DateTime(2023, 3, 10, 16, 0, 0),
+                        Location = "Centro Diurno"
+                    },
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "Intermedia",
+                        TypeDisplay = "Visita Intermedia",
+                        ScheduledDate = new DateTime(2023, 9, 20, 11, 0, 0),
+                        IsCompleted = true,
+                        CompletedDate = new DateTime(2023, 9, 20, 12, 15, 0),
+                        Location = "Ambulatorio"
+                    },
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "Intermedia",
+                        TypeDisplay = "Visita Intermedia",
+                        ScheduledDate = new DateTime(2024, 6, 5, 15, 30, 0),
+                        IsCompleted = false,
+                        Location = "Centro Diurno"
+                    }
+                }
+            },
+            new ProjectViewModel
+            {
+                Id = Guid.NewGuid(),
+                Title = "PTRP 2022-2024",
+                Description = "Progetto completato con successo - integrazione lavorativa",
+                StartDate = new DateTime(2022, 1, 10),
+                EndDate = new DateTime(2024, 12, 31),
+                State = "Completed",
+                CreatedAt = new DateTime(2022, 1, 5),
+                CompletedAt = new DateTime(2024, 12, 20),
+                Patient = new ProjectPatientViewModel
+                {
+                    PatientId = Guid.NewGuid(),
+                    FirstName = "Giuseppe",
+                    LastName = "Neri",
+                    BirthDate = new DateTime(1988, 4, 15)
+                },
+                Educators = new List<ProjectEducatorViewModel>
+                {
+                    new ProjectEducatorViewModel
+                    {
+                        EducatorId = Guid.NewGuid(),
+                        FirstName = "Giovanni",
+                        LastName = "Rossi",
+                        Initials = "GR"
+                    }
+                },
+                Appointments = new List<ProjectAppointmentViewModel>
+                {
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "PrimaApertura",
+                        TypeDisplay = "Prima Apertura",
+                        ScheduledDate = new DateTime(2022, 1, 20, 14, 0, 0),
+                        IsCompleted = true,
+                        CompletedDate = new DateTime(2022, 1, 20, 15, 30, 0),
+                        Location = "Centro Diurno"
+                    },
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "Intermedia",
+                        TypeDisplay = "Visita Intermedia",
+                        ScheduledDate = new DateTime(2022, 6, 10, 10, 0, 0),
+                        IsCompleted = true,
+                        CompletedDate = new DateTime(2022, 6, 10, 11, 15, 0),
+                        Location = "Ambulatorio"
+                    },
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "Intermedia",
+                        TypeDisplay = "Visita Intermedia",
+                        ScheduledDate = new DateTime(2023, 1, 15, 15, 0, 0),
+                        IsCompleted = true,
+                        CompletedDate = new DateTime(2023, 1, 15, 16, 30, 0),
+                        Location = "Centro Diurno"
+                    },
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "Intermedia",
+                        TypeDisplay = "Visita Intermedia",
+                        ScheduledDate = new DateTime(2023, 9, 5, 11, 30, 0),
+                        IsCompleted = true,
+                        CompletedDate = new DateTime(2023, 9, 5, 12, 45, 0),
+                        Location = "Ambulatorio"
+                    },
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "Intermedia",
+                        TypeDisplay = "Visita Intermedia",
+                        ScheduledDate = new DateTime(2024, 6, 20, 14, 0, 0),
+                        IsCompleted = true,
+                        CompletedDate = new DateTime(2024, 6, 20, 15, 30, 0),
+                        Location = "Centro Diurno"
+                    },
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "Finale",
+                        TypeDisplay = "Visita Finale",
+                        ScheduledDate = new DateTime(2024, 12, 15, 10, 0, 0),
+                        IsCompleted = true,
+                        CompletedDate = new DateTime(2024, 12, 15, 11, 45, 0),
+                        Location = "Ambulatorio"
+                    }
+                }
+            },
+            new ProjectViewModel
+            {
+                Id = Guid.NewGuid(),
+                Title = "PTRP 2025-2028",
+                Description = "Progetto triennale per sviluppo relazioni interpersonali",
+                StartDate = new DateTime(2025, 1, 5),
+                EndDate = new DateTime(2028, 1, 5),
+                State = "Active",
+                CreatedAt = new DateTime(2024, 12, 20),
+                Patient = new ProjectPatientViewModel
+                {
+                    PatientId = Guid.NewGuid(),
+                    FirstName = "Francesca",
+                    LastName = "Blu",
+                    BirthDate = new DateTime(1995, 9, 12)
+                },
+                Educators = new List<ProjectEducatorViewModel>
+                {
+                    new ProjectEducatorViewModel
+                    {
+                        EducatorId = Guid.NewGuid(),
+                        FirstName = "Mario",
+                        LastName = "Bianchi",
+                        Initials = "MB"
+                    },
+                    new ProjectEducatorViewModel
+                    {
+                        EducatorId = Guid.NewGuid(),
+                        FirstName = "Laura",
+                        LastName = "Verdi",
+                        Initials = "LV"
+                    },
+                    new ProjectEducatorViewModel
+                    {
+                        EducatorId = Guid.NewGuid(),
+                        FirstName = "Giovanni",
+                        LastName = "Rossi",
+                        Initials = "GR"
+                    }
+                },
+                Appointments = new List<ProjectAppointmentViewModel>
+                {
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "PrimaApertura",
+                        TypeDisplay = "Prima Apertura",
+                        ScheduledDate = new DateTime(2025, 1, 20, 14, 30, 0),
+                        IsCompleted = true,
+                        CompletedDate = new DateTime(2025, 1, 20, 16, 0, 0),
+                        Location = "Centro Diurno"
+                    },
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "Intermedia",
+                        TypeDisplay = "Visita Intermedia",
+                        ScheduledDate = new DateTime(2025, 3, 10, 15, 0, 0),
+                        IsCompleted = false,
+                        Location = "Centro Diurno"
+                    },
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "Intermedia",
+                        TypeDisplay = "Visita Intermedia",
+                        ScheduledDate = new DateTime(2025, 6, 5, 10, 30, 0),
+                        IsCompleted = false,
+                        Location = "Ambulatorio"
+                    },
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "Intermedia",
+                        TypeDisplay = "Visita Intermedia",
+                        ScheduledDate = new DateTime(2025, 9, 15, 14, 0, 0),
+                        IsCompleted = false,
+                        Location = "Centro Diurno"
+                    },
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "Intermedia",
+                        TypeDisplay = "Visita Intermedia",
+                        ScheduledDate = new DateTime(2026, 1, 10, 11, 0, 0),
+                        IsCompleted = false,
+                        Location = "Ambulatorio"
+                    },
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "Intermedia",
+                        TypeDisplay = "Visita Intermedia",
+                        ScheduledDate = new DateTime(2027, 6, 20, 15, 30, 0),
+                        IsCompleted = false,
+                        Location = "Centro Diurno"
+                    },
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "Finale",
+                        TypeDisplay = "Visita Finale",
+                        ScheduledDate = new DateTime(2027, 12, 30, 14, 0, 0),
+                        IsCompleted = false,
+                        Location = "Centro Diurno"
+                    }
+                }
+            },
+            new ProjectViewModel
+            {
+                Id = Guid.NewGuid(),
+                Title = "PTRP 2023-2025",
+                Description = "Progetto interrotto per decesso del paziente",
+                StartDate = new DateTime(2023, 6, 1),
+                EndDate = new DateTime(2025, 5, 31),
+                State = "Deceased",
+                CreatedAt = new DateTime(2023, 5, 20),
+                CompletedAt = new DateTime(2025, 2, 5),
+                Patient = new ProjectPatientViewModel
+                {
+                    PatientId = Guid.NewGuid(),
+                    FirstName = "Paolo",
+                    LastName = "Grigi",
+                    BirthDate = new DateTime(1980, 12, 8)
+                },
+                Educators = new List<ProjectEducatorViewModel>
+                {
+                    new ProjectEducatorViewModel
+                    {
+                        EducatorId = Guid.NewGuid(),
+                        FirstName = "Laura",
+                        LastName = "Verdi",
+                        Initials = "LV"
+                    }
+                },
+                Appointments = new List<ProjectAppointmentViewModel>
+                {
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "PrimaApertura",
+                        TypeDisplay = "Prima Apertura",
+                        ScheduledDate = new DateTime(2023, 6, 15, 14, 30, 0),
+                        IsCompleted = true,
+                        CompletedDate = new DateTime(2023, 6, 15, 16, 0, 0),
+                        Location = "Centro Diurno"
+                    },
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "Intermedia",
+                        TypeDisplay = "Visita Intermedia",
+                        ScheduledDate = new DateTime(2023, 12, 10, 10, 0, 0),
+                        IsCompleted = true,
+                        CompletedDate = new DateTime(2023, 12, 10, 11, 30, 0),
+                        Location = "Ambulatorio"
+                    },
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "Intermedia",
+                        TypeDisplay = "Visita Intermedia",
+                        ScheduledDate = new DateTime(2024, 6, 20, 14, 0, 0),
+                        IsCompleted = true,
+                        CompletedDate = new DateTime(2024, 6, 20, 15, 15, 0),
+                        Location = "Centro Diurno"
+                    },
+                    new ProjectAppointmentViewModel
+                    {
+                        AppointmentId = Guid.NewGuid(),
+                        Type = "Finale",
+                        TypeDisplay = "Visita Finale",
+                        ScheduledDate = new DateTime(2025, 5, 20, 10, 0, 0),
+                        IsCompleted = false,
+                        Location = "Ambulatorio"
+                    }
+                }
+            }
+        };
+    }
+
+    // Property changed handlers per aggiornamento automatico filtri
+    partial void OnSearchTermChanged(string value)
+    {
+        ApplyFilters();
+    }
+
+    partial void OnSelectedStateFilterChanged(string value)
+    {
+        ApplyFilters();
+    }
+}

--- a/src/PTRP.ViewModels/Projects/ProjectPatientViewModel.cs
+++ b/src/PTRP.ViewModels/Projects/ProjectPatientViewModel.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace PTRP.ViewModels.Projects;
+
+/// <summary>
+/// ViewModel per rappresentare un paziente collegato a un progetto.
+/// Utilizzato nella sezione paziente del detail panel progetto.
+/// </summary>
+public class ProjectPatientViewModel
+{
+    /// <summary>
+    /// ID univoco del paziente.
+    /// </summary>
+    public Guid PatientId { get; set; }
+
+    /// <summary>
+    /// Nome del paziente.
+    /// </summary>
+    public string FirstName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Cognome del paziente.
+    /// </summary>
+    public string LastName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Nome completo (Nome + Cognome).
+    /// </summary>
+    public string FullName => $"{FirstName} {LastName}";
+
+    /// <summary>
+    /// Data di nascita del paziente.
+    /// </summary>
+    public DateTime BirthDate { get; set; }
+
+    /// <summary>
+    /// Età calcolata del paziente.
+    /// </summary>
+    public int Age => DateTime.Now.Year - BirthDate.Year;
+}

--- a/src/PTRP.ViewModels/Projects/ProjectViewModel.cs
+++ b/src/PTRP.ViewModels/Projects/ProjectViewModel.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PTRP.ViewModels.Projects;
+
+/// <summary>
+/// ViewModel per rappresentare un Progetto Terapeutico Riabilitativo Personalizzato.
+/// Utilizzato sia nella lista master che nel detail panel.
+/// </summary>
+public class ProjectViewModel
+{
+    /// <summary>
+    /// ID univoco del progetto.
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Titolo del progetto (es: "PTRP 2025-2027").
+    /// </summary>
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Descrizione dettagliata del progetto.
+    /// </summary>
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Data inizio progetto.
+    /// </summary>
+    public DateTime StartDate { get; set; }
+
+    /// <summary>
+    /// Data fine progetto.
+    /// </summary>
+    public DateTime EndDate { get; set; }
+
+    /// <summary>
+    /// Periodo formattato (es: "gennaio 2025 - dicembre 2027").
+    /// </summary>
+    public string Period => $"{StartDate:MMMM yyyy} - {EndDate:MMMM yyyy}";
+
+    /// <summary>
+    /// Periodo formattato breve (es: "01/2025 - 12/2027").
+    /// </summary>
+    public string PeriodShort => $"{StartDate:MM/yyyy} - {EndDate:MM/yyyy}";
+
+    /// <summary>
+    /// Stato del progetto: "Active", "Suspended", "Completed", "Deceased".
+    /// </summary>
+    public string State { get; set; } = "Active";
+
+    /// <summary>
+    /// Stato formattato per visualizzazione.
+    /// </summary>
+    public string StateDisplay => State switch
+    {
+        "Active" => "Attivo",
+        "Suspended" => "Sospeso",
+        "Completed" => "Completato",
+        "Deceased" => "Deceduto",
+        _ => "Sconosciuto"
+    };
+
+    /// <summary>
+    /// Data di creazione del progetto.
+    /// </summary>
+    public DateTime CreatedAt { get; set; }
+
+    /// <summary>
+    /// Data di sospensione (se presente).
+    /// </summary>
+    public DateTime? SuspendedAt { get; set; }
+
+    /// <summary>
+    /// Data di completamento (se presente).
+    /// </summary>
+    public DateTime? CompletedAt { get; set; }
+
+    /// <summary>
+    /// Motivazione della sospensione (se presente).
+    /// </summary>
+    public string? SuspensionReason { get; set; }
+
+    // === Relazioni ===
+
+    /// <summary>
+    /// Paziente collegato al progetto.
+    /// </summary>
+    public ProjectPatientViewModel Patient { get; set; } = new();
+
+    /// <summary>
+    /// Lista educatori assegnati al progetto.
+    /// </summary>
+    public List<ProjectEducatorViewModel> Educators { get; set; } = new();
+
+    /// <summary>
+    /// Numero di educatori assegnati.
+    /// </summary>
+    public int EducatorCount => Educators.Count;
+
+    /// <summary>
+    /// Nomi educatori separati da virgola (solo cognomi).
+    /// </summary>
+    public string EducatorNamesDisplay => string.Join(", ", Educators.Select(e => e.LastName));
+
+    /// <summary>
+    /// Lista appuntamenti/visite collegati al progetto.
+    /// </summary>
+    public List<ProjectAppointmentViewModel> Appointments { get; set; } = new();
+
+    /// <summary>
+    /// Numero totale di appuntamenti.
+    /// </summary>
+    public int TotalAppointments => Appointments.Count;
+
+    /// <summary>
+    /// Numero di appuntamenti completati.
+    /// </summary>
+    public int CompletedAppointments => Appointments.Count(a => a.IsCompleted);
+
+    /// <summary>
+    /// Prossimo appuntamento programmato (se presente).
+    /// </summary>
+    public ProjectAppointmentViewModel? NextAppointment => 
+        Appointments
+            .Where(a => !a.IsCompleted && a.ScheduledDate > DateTime.Now)
+            .OrderBy(a => a.ScheduledDate)
+            .FirstOrDefault();
+
+    // === UI Helpers ===
+
+    /// <summary>
+    /// Progresso visite formattato (es: "2/5 visite").
+    /// </summary>
+    public string ProgressDisplay => $"{CompletedAppointments}/{TotalAppointments} visite";
+
+    /// <summary>
+    /// Percentuale progresso visite (0-100).
+    /// </summary>
+    public double ProgressPercentage => TotalAppointments > 0 
+        ? (double)CompletedAppointments / TotalAppointments * 100 
+        : 0;
+}


### PR DESCRIPTION
## 📋 Descrizione

Implementa **ProjectListView** con layout **Master-Detail 2*:1*** seguendo il pattern architetturale di PatientListView (Issue #51) ed EducatorListView (Issue #63).

---

## ✅ Cambiamenti Implementati

### ViewModels (`src/PTRP.ViewModels/Projects/`)
- ✅ **ProjectEducatorViewModel** - Rappresentazione educatore nel detail panel (senza Role)
- ✅ **ProjectPatientViewModel** - Informazioni paziente collegato
- ✅ **ProjectAppointmentViewModel** - Appuntamenti/visite del progetto
- ✅ **ProjectViewModel** - Modello principale progetto con relazioni e calcoli
- ✅ **ProjectListViewModel** - ViewModel lista con search, filtri e caricamento dati

### Views (`src/PTRP.App/Views/Projects/`)
- ✅ **ProjectListView.xaml** - Master-Detail layout con:
  - DataGrid READ-ONLY per lista progetti
  - Search box real-time
  - ComboBox filtro stato (Tutti, Active, Suspended, Completed, Deceased)
  - Detail panel con:
    - Info progetto (periodo, stato, date)
    - Sezione paziente con età e link
    - Lista educatori assegnati
    - Progress bar visite (X/Y completate) con **binding OneWay** 🐛 fix
    - Timeline appuntamenti ordinata
    - Azioni rapide (Modifica, Sospendi, Completa)
- ✅ **ProjectListView.xaml.cs** - Code-behind view

### Integration
- ✅ **App.xaml** - Registrato DataTemplate per ProjectListViewModel
- ✅ **App.xaml.cs** - Registrati ViewModel e View nel DI container
- ✅ **MainViewModel.cs** - Abilitata navigazione:
  - Decommentato `ViewModelType` nel menu "Progetti"
  - Aggiunto case `ProjectListViewModel` in `OnCurrentViewModelChanged`
  - Modificato `NavigateToProjects()` per navigazione reale

---

## 🐛 Bug Fix

**Issue**: `System.InvalidOperationException` quando si selezionava un progetto:
```
Non è possibile usare un binding TwoWay o OneWayToSource 
per la proprietà di sola lettura 'ProgressPercentage'
```

**Causa**: ProgressBar di default usa binding `TwoWay` ma `ProgressPercentage` è una proprietà calcolata read-only.

**Fix**: Impostato esplicitamente `Mode=OneWay` nel binding:
```xml
<ProgressBar Value="{Binding SelectedProject.ProgressPercentage, Mode=OneWay}" 
             Maximum="100" Height="8" 
             Style="{StaticResource MaterialDesignLinearProgressBar}"/>
```

---

## 🎯 Acceptance Criteria Soddisfatti

### Funzionalità
- ✅ Layout Master-Detail 2*:1* implementato
- ✅ DataGrid lista progetti READ-ONLY con 5 colonne
- ✅ Search box real-time su titolo/paziente
- ✅ Filtro ComboBox per stato
- ✅ Selezione progetto aggiorna detail panel
- ✅ Detail panel nascosto quando nessuna selezione

### Detail Panel
- ✅ Header con titolo + azioni (Modifica, Sospendi, Completa)
- ✅ Sezione Info Progetto con periodo, stato, date importanti
- ✅ Sezione Paziente con nome, età, link "Visualizza Scheda"
- ✅ Sezione Educatori con avatar circolare + iniziali
- ✅ Progress bar visite con percentuale (bug fixed)
- ✅ Timeline appuntamenti con icone differenziate
- ✅ Bottoni azioni rapide (Nuovo Appuntamento, Storico Visite)

### UI/UX
- ✅ Badge colorato per stato (riuso `ProjectStateToColorConverter` da Issue #51)
- ✅ Riuso `NullToVisibilityConverter` da Issue #51
- ✅ Icone differenziate appuntamenti completati/programmati
- ✅ Material Design 3 styling consistent
- ✅ Dark/Light mode supportato

### Architettura
- ✅ Pattern MVVM completo
- ✅ ViewModels in `PTRP.ViewModels/Projects/`
- ✅ View in `PTRP.App/Views/Projects/`
- ✅ DataTemplate registrato in App.xaml
- ✅ ViewModel/View registrati in DI
- ✅ Navigation funzionante da menu "Progetti"
- ✅ LoadProjectsAsync in `OnCurrentViewModelChanged`

---

## 📊 Dati di Test

6 progetti di test generati con dati realistici:
1. **PTRP 2025-2027** - Mario Rossi - Active - 2 educatori - 5 appuntamenti (2 completati)
2. **PTRP 2024-2026** - Luca Bianchi - Active - 1 educatore - 4 appuntamenti (3 completati)
3. **PTRP 2023-2025** - Anna Verdi - Suspended - 1 educatore - 3 appuntamenti (2 completati)
4. **PTRP 2022-2024** - Giuseppe Neri - Completed - 1 educatore - 6 appuntamenti (tutti completati)
5. **PTRP 2025-2028** - Francesca Blu - Active - 3 educatori - 7 appuntamenti (1 completato)
6. **PTRP 2023-2025** - Paolo Grigi - Deceased - 1 educatore - 4 appuntamenti (3 completati)

---

## 🔗 Relazioni

**Dipende da:**
- ✅ Issue #51 (PatientListView) - Pattern e converter riutilizzati
- ✅ Issue #46 (NavigationService) - Già implementato
- ✅ Issue #63 (EducatorListView) - Pattern master-detail consolidato

**Chiude:**
- Closes #64

**Fase 2 Completata:**
- ✅ Issue #51 - PatientListView
- ✅ Issue #63 - EducatorListView  
- ✅ Issue #64 - ProjectListView

---

## 🧪 Testing Manuale

**Verificato:**
1. ✅ Build successful senza warning
2. ✅ Nessun errore runtime
3. ✅ 6 progetti caricati correttamente
4. ✅ Search funziona su titolo + paziente
5. ✅ Filtri stato funzionanti
6. ✅ Selezione aggiorna detail panel **senza errori**
7. ✅ Progress bar calcolo corretto e visualizzato
8. ✅ Timeline appuntamenti ordinata per data
9. ✅ Badge stato colorati (Verde/Giallo/Grigio/Nero)
10. ✅ Navigation da menu laterale OK
11. ✅ Detail panel si nasconde se nessuna selezione

---

## 📝 Note Implementative

### Riuso da Issue Precedenti
- ✅ `ProjectStateToColorConverter` già disponibile da Issue #51
- ✅ `NullToVisibilityConverter` già disponibile da Issue #51
- ✅ Pattern Master-Detail consolidato
- ✅ Search real-time con `UpdateSourceTrigger=PropertyChanged`
- ✅ DataGrid styling MaterialDesign consistent

### Complessità Extra
- **Timeline Appuntamenti** con ItemsControl custom template
- **Progress Visite** con ProgressBar e calcolo percentuale (fixed binding mode)
- **Relazioni Multiple** (Paziente + Educatori + Appuntamenti)
- **Stati Temporali** (SuspendedAt, CompletedAt con Visibility conditional)

### TODO Future (Non bloccanti)
- Integrare `IProjectService` quando disponibile
- Implementare "Nuovo Appuntamento" (modal/dialog)
- Implementare "Modifica" progetto
- Implementare "Sospendi" con dialog motivo
- Implementare "Completa" con conferma
- Implementare "Storico Visite"
- Link "Visualizza Scheda Paziente" con navigation
- Caricare appuntamenti da database
- Ordinamento DataGrid colonne

---

## 🎯 Definition of Done

- ✅ Codice committato su branch `feat/issue-64-project-list-view`
- ✅ Tutti gli Acceptance Criteria soddisfatti
- ✅ Bug ProgressBar binding risolto
- ✅ 4 ViewModels + 2 Views + 3 integration files
- ✅ Navigation funzionante
- ✅ 6 progetti di test caricati
- ✅ Timeline e progress bar funzionanti
- ✅ Testing manuale completato con successo
- ✅ Pull Request creata su `develop`
- ⏳ Code review
- ⏳ Merge

---

**🏗️ Progetto è l'entità più complessa - fondamentale per Fase 3 (Visite)!**

**FASE 2 COMPLETATA CON SUCCESSO! 🎉**