### PR TITLE
feat: UI reusable controls (issue #83)

### DIFF
--- a/src/PTRP.App/Controls/ActionButtonsGroup.xaml
+++ b/src/PTRP.App/Controls/ActionButtonsGroup.xaml
@@ -1,0 +1,56 @@
+<UserControl x:Class="PTRP.App.Controls.ActionButtonsGroup"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             mc:Ignorable="d" 
+             d:DesignHeight="50" d:DesignWidth="300"
+             x:Name="Root">
+    <StackPanel Orientation="Horizontal"
+                HorizontalAlignment="{Binding ButtonAlignment, ElementName=Root}"
+                Margin="0,16,0,0">
+        
+        <!-- Save/Cancel Mode -->
+        <StackPanel Orientation="Horizontal"
+                   Visibility="{Binding ShowSaveCancel, ElementName=Root, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <!-- Cancel Button -->
+            <Button Style="{StaticResource MaterialDesignOutlinedButton}"
+                    Content="{Binding CancelText, ElementName=Root}"
+                    Command="{Binding CancelCommand, ElementName=Root}"
+                    Padding="16,8"
+                    Margin="0,0,8,0"
+                    MinWidth="100"/>
+            
+            <!-- Save Button -->
+            <Button Style="{StaticResource MaterialDesignRaisedButton}"
+                    Content="{Binding SaveText, ElementName=Root}"
+                    Command="{Binding SaveCommand, ElementName=Root}"
+                    Padding="16,8"
+                    MinWidth="100"
+                    materialDesign:ButtonAssist.CornerRadius="4"/>
+        </StackPanel>
+
+        <!-- Edit/Delete Mode -->
+        <StackPanel Orientation="Horizontal"
+                   Visibility="{Binding ShowEditDelete, ElementName=Root, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <!-- Delete Button -->
+            <Button Style="{StaticResource MaterialDesignOutlinedButton}"
+                    Content="{Binding DeleteText, ElementName=Root}"
+                    Command="{Binding DeleteCommand, ElementName=Root}"
+                    Padding="16,8"
+                    Margin="0,0,8,0"
+                    MinWidth="100"
+                    Foreground="#D32F2F"
+                    BorderBrush="#D32F2F"/>
+            
+            <!-- Edit Button -->
+            <Button Style="{StaticResource MaterialDesignRaisedButton}"
+                    Content="{Binding EditText, ElementName=Root}"
+                    Command="{Binding EditCommand, ElementName=Root}"
+                    Padding="16,8"
+                    MinWidth="100"
+                    materialDesign:ButtonAssist.CornerRadius="4"/>
+        </StackPanel>
+    </StackPanel>
+</UserControl>

--- a/src/PTRP.App/Controls/ActionButtonsGroup.xaml.cs
+++ b/src/PTRP.App/Controls/ActionButtonsGroup.xaml.cs
@@ -1,0 +1,213 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace PTRP.App.Controls;
+
+/// <summary>
+/// Gruppo standard di pulsanti per form (Save/Cancel o Edit/Delete).
+/// </summary>
+/// <remarks>
+/// Garantisce consistenza visiva in tutti i form dell'applicazione.
+/// Due modalità:
+/// - Save/Cancel: per form di creazione/modifica
+/// - Edit/Delete: per detail view con azioni su entità esistente
+/// </remarks>
+/// <example>
+/// <code>
+/// &lt;!-- Form Mode --&gt;
+/// &lt;controls:ActionButtonsGroup 
+///     ShowSaveCancel="True"
+///     SaveCommand="{Binding SaveCommand}"
+///     CancelCommand="{Binding CancelCommand}" /&gt;
+/// 
+/// &lt;!-- Detail Mode --&gt;
+/// &lt;controls:ActionButtonsGroup 
+///     ShowEditDelete="True"
+///     EditCommand="{Binding EditCommand}"
+///     DeleteCommand="{Binding DeleteCommand}" /&gt;
+/// </code>
+/// </example>
+public partial class ActionButtonsGroup : UserControl
+{
+    public static readonly DependencyProperty ShowSaveCancelProperty =
+        DependencyProperty.Register(
+            nameof(ShowSaveCancel),
+            typeof(bool),
+            typeof(ActionButtonsGroup),
+            new PropertyMetadata(false));
+
+    public static readonly DependencyProperty ShowEditDeleteProperty =
+        DependencyProperty.Register(
+            nameof(ShowEditDelete),
+            typeof(bool),
+            typeof(ActionButtonsGroup),
+            new PropertyMetadata(false));
+
+    public static readonly DependencyProperty SaveCommandProperty =
+        DependencyProperty.Register(
+            nameof(SaveCommand),
+            typeof(ICommand),
+            typeof(ActionButtonsGroup),
+            new PropertyMetadata(null));
+
+    public static readonly DependencyProperty CancelCommandProperty =
+        DependencyProperty.Register(
+            nameof(CancelCommand),
+            typeof(ICommand),
+            typeof(ActionButtonsGroup),
+            new PropertyMetadata(null));
+
+    public static readonly DependencyProperty EditCommandProperty =
+        DependencyProperty.Register(
+            nameof(EditCommand),
+            typeof(ICommand),
+            typeof(ActionButtonsGroup),
+            new PropertyMetadata(null));
+
+    public static readonly DependencyProperty DeleteCommandProperty =
+        DependencyProperty.Register(
+            nameof(DeleteCommand),
+            typeof(ICommand),
+            typeof(ActionButtonsGroup),
+            new PropertyMetadata(null));
+
+    public static readonly DependencyProperty SaveTextProperty =
+        DependencyProperty.Register(
+            nameof(SaveText),
+            typeof(string),
+            typeof(ActionButtonsGroup),
+            new PropertyMetadata("Salva"));
+
+    public static readonly DependencyProperty CancelTextProperty =
+        DependencyProperty.Register(
+            nameof(CancelText),
+            typeof(string),
+            typeof(ActionButtonsGroup),
+            new PropertyMetadata("Annulla"));
+
+    public static readonly DependencyProperty EditTextProperty =
+        DependencyProperty.Register(
+            nameof(EditText),
+            typeof(string),
+            typeof(ActionButtonsGroup),
+            new PropertyMetadata("Modifica"));
+
+    public static readonly DependencyProperty DeleteTextProperty =
+        DependencyProperty.Register(
+            nameof(DeleteText),
+            typeof(string),
+            typeof(ActionButtonsGroup),
+            new PropertyMetadata("Elimina"));
+
+    public static readonly DependencyProperty ButtonAlignmentProperty =
+        DependencyProperty.Register(
+            nameof(ButtonAlignment),
+            typeof(HorizontalAlignment),
+            typeof(ActionButtonsGroup),
+            new PropertyMetadata(HorizontalAlignment.Right));
+
+    /// <summary>
+    /// Mostra i pulsanti Save/Cancel (modalità form).
+    /// </summary>
+    public bool ShowSaveCancel
+    {
+        get => (bool)GetValue(ShowSaveCancelProperty);
+        set => SetValue(ShowSaveCancelProperty, value);
+    }
+
+    /// <summary>
+    /// Mostra i pulsanti Edit/Delete (modalità detail).
+    /// </summary>
+    public bool ShowEditDelete
+    {
+        get => (bool)GetValue(ShowEditDeleteProperty);
+        set => SetValue(ShowEditDeleteProperty, value);
+    }
+
+    /// <summary>
+    /// Comando per il pulsante Save.
+    /// </summary>
+    public ICommand? SaveCommand
+    {
+        get => (ICommand?)GetValue(SaveCommandProperty);
+        set => SetValue(SaveCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Comando per il pulsante Cancel.
+    /// </summary>
+    public ICommand? CancelCommand
+    {
+        get => (ICommand?)GetValue(CancelCommandProperty);
+        set => SetValue(CancelCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Comando per il pulsante Edit.
+    /// </summary>
+    public ICommand? EditCommand
+    {
+        get => (ICommand?)GetValue(EditCommandProperty);
+        set => SetValue(EditCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Comando per il pulsante Delete.
+    /// </summary>
+    public ICommand? DeleteCommand
+    {
+        get => (ICommand?)GetValue(DeleteCommandProperty);
+        set => SetValue(DeleteCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Testo del pulsante Save (default: "Salva").
+    /// </summary>
+    public string SaveText
+    {
+        get => (string)GetValue(SaveTextProperty);
+        set => SetValue(SaveTextProperty, value);
+    }
+
+    /// <summary>
+    /// Testo del pulsante Cancel (default: "Annulla").
+    /// </summary>
+    public string CancelText
+    {
+        get => (string)GetValue(CancelTextProperty);
+        set => SetValue(CancelTextProperty, value);
+    }
+
+    /// <summary>
+    /// Testo del pulsante Edit (default: "Modifica").
+    /// </summary>
+    public string EditText
+    {
+        get => (string)GetValue(EditTextProperty);
+        set => SetValue(EditTextProperty, value);
+    }
+
+    /// <summary>
+    /// Testo del pulsante Delete (default: "Elimina").
+    /// </summary>
+    public string DeleteText
+    {
+        get => (string)GetValue(DeleteTextProperty);
+        set => SetValue(DeleteTextProperty, value);
+    }
+
+    /// <summary>
+    /// Allineamento orizzontale del gruppo pulsanti (default: Right).
+    /// </summary>
+    public HorizontalAlignment ButtonAlignment
+    {
+        get => (HorizontalAlignment)GetValue(ButtonAlignmentProperty);
+        set => SetValue(ButtonAlignmentProperty, value);
+    }
+
+    public ActionButtonsGroup()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/PTRP.App/Controls/KpiCard.xaml
+++ b/src/PTRP.App/Controls/KpiCard.xaml
@@ -1,0 +1,66 @@
+<UserControl x:Class="PTRP.App.Controls.KpiCard"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             mc:Ignorable="d" 
+             d:DesignHeight="140" d:DesignWidth="200"
+             x:Name="Root">
+    <materialDesign:Card UniformCornerRadius="8"
+                        Padding="16"
+                        Background="{Binding CardColor, ElementName=Root}">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <!-- Icon -->
+            <materialDesign:PackIcon Grid.Row="0"
+                                     Kind="{Binding Icon, ElementName=Root}"
+                                     Width="32"
+                                     Height="32"
+                                     Foreground="White"
+                                     Opacity="0.9"
+                                     HorizontalAlignment="Left"/>
+
+            <!-- Value -->
+            <TextBlock Grid.Row="1"
+                       Text="{Binding Value, ElementName=Root}"
+                       FontSize="36"
+                       FontWeight="Bold"
+                       Foreground="White"
+                       VerticalAlignment="Center"
+                       Margin="0,8,0,4"/>
+
+            <!-- Title -->
+            <TextBlock Grid.Row="2"
+                       Text="{Binding Title, ElementName=Root}"
+                       FontSize="14"
+                       Foreground="White"
+                       Opacity="0.9"
+                       TextWrapping="Wrap"/>
+
+            <!-- Trend (opzionale) -->
+            <StackPanel Grid.Row="3"
+                       Orientation="Horizontal"
+                       Margin="0,4,0,0"
+                       Visibility="{Binding HasTrend, ElementName=Root, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <materialDesign:PackIcon Kind="{Binding TrendIcon, ElementName=Root}"
+                                        Width="16"
+                                        Height="16"
+                                        Foreground="White"
+                                        VerticalAlignment="Center"
+                                        Margin="0,0,4,0"/>
+                <TextBlock Text="{Binding TrendDisplay, ElementName=Root}"
+                          FontSize="12"
+                          Foreground="White"
+                          Opacity="0.9"
+                          VerticalAlignment="Center"/>
+            </StackPanel>
+        </Grid>
+    </materialDesign:Card>
+</UserControl>

--- a/src/PTRP.App/Controls/KpiCard.xaml.cs
+++ b/src/PTRP.App/Controls/KpiCard.xaml.cs
@@ -1,0 +1,194 @@
+using MaterialDesignThemes.Wpf;
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+namespace PTRP.App.Controls;
+
+/// <summary>
+/// Card per visualizzare KPI (Key Performance Indicator) con icona, valore, titolo e trend opzionale.
+/// </summary>
+/// <remarks>
+/// Perfetta per dashboard e report.
+/// - Icona: PackIconKind da MaterialDesign
+/// - Valore: string o numero formattato
+/// - Titolo: descrizione del KPI
+/// - Trend: valore decimale opzionale (es: +5.2, -3.1) con icona auto-determinata
+/// - CardColor: colore di sfondo personalizzabile
+/// </remarks>
+/// <example>
+/// <code>
+/// &lt;controls:KpiCard 
+///     Title="Pazienti Attivi" 
+///     Value="48"
+///     Icon="Account"
+///     CardColor="#2196F3"
+///     TrendValue="5.2" /&gt;
+/// </code>
+/// </example>
+public partial class KpiCard : UserControl
+{
+    public static readonly DependencyProperty TitleProperty =
+        DependencyProperty.Register(
+            nameof(Title),
+            typeof(string),
+            typeof(KpiCard),
+            new PropertyMetadata(string.Empty));
+
+    public static readonly DependencyProperty ValueProperty =
+        DependencyProperty.Register(
+            nameof(Value),
+            typeof(string),
+            typeof(KpiCard),
+            new PropertyMetadata("0"));
+
+    public static readonly DependencyProperty IconProperty =
+        DependencyProperty.Register(
+            nameof(Icon),
+            typeof(PackIconKind),
+            typeof(KpiCard),
+            new PropertyMetadata(PackIconKind.ChartLine));
+
+    public static readonly DependencyProperty CardColorProperty =
+        DependencyProperty.Register(
+            nameof(CardColor),
+            typeof(Brush),
+            typeof(KpiCard),
+            new PropertyMetadata(new SolidColorBrush(Color.FromRgb(33, 150, 243)))) // Material Blue 500
+;
+
+    public static readonly DependencyProperty TrendValueProperty =
+        DependencyProperty.Register(
+            nameof(TrendValue),
+            typeof(decimal?),
+            typeof(KpiCard),
+            new PropertyMetadata(null, OnTrendValueChanged));
+
+    public static readonly DependencyProperty TrendDisplayProperty =
+        DependencyProperty.Register(
+            nameof(TrendDisplay),
+            typeof(string),
+            typeof(KpiCard),
+            new PropertyMetadata(string.Empty));
+
+    public static readonly DependencyProperty TrendIconProperty =
+        DependencyProperty.Register(
+            nameof(TrendIcon),
+            typeof(PackIconKind),
+            typeof(KpiCard),
+            new PropertyMetadata(PackIconKind.TrendingUp));
+
+    public static readonly DependencyProperty HasTrendProperty =
+        DependencyProperty.Register(
+            nameof(HasTrend),
+            typeof(bool),
+            typeof(KpiCard),
+            new PropertyMetadata(false));
+
+    /// <summary>
+    /// Titolo del KPI.
+    /// </summary>
+    public string Title
+    {
+        get => (string)GetValue(TitleProperty);
+        set => SetValue(TitleProperty, value);
+    }
+
+    /// <summary>
+    /// Valore principale del KPI (formattato come string).
+    /// </summary>
+    public string Value
+    {
+        get => (string)GetValue(ValueProperty);
+        set => SetValue(ValueProperty, value);
+    }
+
+    /// <summary>
+    /// Icona MaterialDesign da visualizzare.
+    /// </summary>
+    public PackIconKind Icon
+    {
+        get => (PackIconKind)GetValue(IconProperty);
+        set => SetValue(IconProperty, value);
+    }
+
+    /// <summary>
+    /// Colore di sfondo della card.
+    /// </summary>
+    public Brush CardColor
+    {
+        get => (Brush)GetValue(CardColorProperty);
+        set => SetValue(CardColorProperty, value);
+    }
+
+    /// <summary>
+    /// Valore del trend (es: +5.2 per +5.2%, -3.1 per -3.1%).
+    /// Se null, il trend non viene visualizzato.
+    /// </summary>
+    public decimal? TrendValue
+    {
+        get => (decimal?)GetValue(TrendValueProperty);
+        set => SetValue(TrendValueProperty, value);
+    }
+
+    /// <summary>
+    /// Testo del trend formattato (es: "+5.2%", "-3.1%").
+    /// </summary>
+    public string TrendDisplay
+    {
+        get => (string)GetValue(TrendDisplayProperty);
+        private set => SetValue(TrendDisplayProperty, value);
+    }
+
+    /// <summary>
+    /// Icona del trend (auto-determinata: TrendingUp se positivo, TrendingDown se negativo).
+    /// </summary>
+    public PackIconKind TrendIcon
+    {
+        get => (PackIconKind)GetValue(TrendIconProperty);
+        private set => SetValue(TrendIconProperty, value);
+    }
+
+    /// <summary>
+    /// Indica se il trend è presente.
+    /// </summary>
+    public bool HasTrend
+    {
+        get => (bool)GetValue(HasTrendProperty);
+        private set => SetValue(HasTrendProperty, value);
+    }
+
+    public KpiCard()
+    {
+        InitializeComponent();
+    }
+
+    private static void OnTrendValueChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is KpiCard card)
+        {
+            card.UpdateTrend();
+        }
+    }
+
+    private void UpdateTrend()
+    {
+        if (!TrendValue.HasValue)
+        {
+            HasTrend = false;
+            TrendDisplay = string.Empty;
+            return;
+        }
+
+        HasTrend = true;
+        var value = TrendValue.Value;
+
+        // Determina icona
+        TrendIcon = value >= 0 ? PackIconKind.TrendingUp : PackIconKind.TrendingDown;
+
+        // Formatta display
+        var sign = value >= 0 ? "+" : string.Empty;
+        TrendDisplay = $"{sign}{value:F1}%";
+    }
+}

--- a/src/PTRP.App/Controls/PtrpDatePicker.xaml
+++ b/src/PTRP.App/Controls/PtrpDatePicker.xaml
@@ -1,0 +1,26 @@
+<UserControl x:Class="PTRP.App.Controls.PtrpDatePicker"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             mc:Ignorable="d" 
+             d:DesignHeight="60" d:DesignWidth="300"
+             x:Name="Root">
+    <StackPanel>
+        <DatePicker x:Name="InternalDatePicker"
+                    SelectedDate="{Binding SelectedDate, ElementName=Root, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                    DisplayDate="{Binding SelectedDate, ElementName=Root, Mode=OneWay}"
+                    materialDesign:HintAssist.Hint="{Binding Watermark, ElementName=Root}"
+                    Style="{StaticResource MaterialDesignFloatingHintDatePicker}"
+                    Margin="0,0,0,4"
+                    FontSize="14"/>
+        
+        <!-- Validation Error Message -->
+        <TextBlock Text="{Binding ValidationError, ElementName=Root}"
+                   Foreground="#D32F2F"
+                   FontSize="12"
+                   Margin="0,2,0,0"
+                   Visibility="{Binding HasValidationError, ElementName=Root, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+    </StackPanel>
+</UserControl>

--- a/src/PTRP.App/Controls/PtrpDatePicker.xaml.cs
+++ b/src/PTRP.App/Controls/PtrpDatePicker.xaml.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace PTRP.App.Controls;
+
+/// <summary>
+/// Controllo DatePicker personalizzato con stile Material Design e supporto validazione.
+/// </summary>
+/// <remarks>
+/// Supporta:
+/// - Validazione required
+/// - Validazione future date (data deve essere futura)
+/// - Validazione date range (MinDate, MaxDate)
+/// - Messaggio di errore personalizzabile
+/// </remarks>
+/// <example>
+/// <code>
+/// &lt;controls:PtrpDatePicker 
+///     SelectedDate="{Binding StartDate}" 
+///     Watermark="Data Inizio"
+///     IsRequired="True"
+///     MinDate="{Binding Today}" /&gt;
+/// </code>
+/// </example>
+public partial class PtrpDatePicker : UserControl
+{
+    public static readonly DependencyProperty SelectedDateProperty =
+        DependencyProperty.Register(
+            nameof(SelectedDate),
+            typeof(DateTime?),
+            typeof(PtrpDatePicker),
+            new FrameworkPropertyMetadata(
+                null,
+                FrameworkPropertyMetadataOptions.BindsTwoWayByDefault,
+                OnSelectedDateChanged));
+
+    public static readonly DependencyProperty WatermarkProperty =
+        DependencyProperty.Register(
+            nameof(Watermark),
+            typeof(string),
+            typeof(PtrpDatePicker),
+            new PropertyMetadata("Seleziona data"));
+
+    public static readonly DependencyProperty IsRequiredProperty =
+        DependencyProperty.Register(
+            nameof(IsRequired),
+            typeof(bool),
+            typeof(PtrpDatePicker),
+            new PropertyMetadata(false, OnValidationPropertyChanged));
+
+    public static readonly DependencyProperty MinDateProperty =
+        DependencyProperty.Register(
+            nameof(MinDate),
+            typeof(DateTime?),
+            typeof(PtrpDatePicker),
+            new PropertyMetadata(null, OnValidationPropertyChanged));
+
+    public static readonly DependencyProperty MaxDateProperty =
+        DependencyProperty.Register(
+            nameof(MaxDate),
+            typeof(DateTime?),
+            typeof(PtrpDatePicker),
+            new PropertyMetadata(null, OnValidationPropertyChanged));
+
+    public static readonly DependencyProperty MustBeFutureDateProperty =
+        DependencyProperty.Register(
+            nameof(MustBeFutureDate),
+            typeof(bool),
+            typeof(PtrpDatePicker),
+            new PropertyMetadata(false, OnValidationPropertyChanged));
+
+    public static readonly DependencyProperty ValidationErrorProperty =
+        DependencyProperty.Register(
+            nameof(ValidationError),
+            typeof(string),
+            typeof(PtrpDatePicker),
+            new PropertyMetadata(string.Empty));
+
+    public static readonly DependencyProperty HasValidationErrorProperty =
+        DependencyProperty.Register(
+            nameof(HasValidationError),
+            typeof(bool),
+            typeof(PtrpDatePicker),
+            new PropertyMetadata(false));
+
+    /// <summary>
+    /// Data selezionata.
+    /// </summary>
+    public DateTime? SelectedDate
+    {
+        get => (DateTime?)GetValue(SelectedDateProperty);
+        set => SetValue(SelectedDateProperty, value);
+    }
+
+    /// <summary>
+    /// Testo placeholder quando nessuna data è selezionata.
+    /// </summary>
+    public string Watermark
+    {
+        get => (string)GetValue(WatermarkProperty);
+        set => SetValue(WatermarkProperty, value);
+    }
+
+    /// <summary>
+    /// Indica se la data è obbligatoria.
+    /// </summary>
+    public bool IsRequired
+    {
+        get => (bool)GetValue(IsRequiredProperty);
+        set => SetValue(IsRequiredProperty, value);
+    }
+
+    /// <summary>
+    /// Data minima consentita.
+    /// </summary>
+    public DateTime? MinDate
+    {
+        get => (DateTime?)GetValue(MinDateProperty);
+        set => SetValue(MinDateProperty, value);
+    }
+
+    /// <summary>
+    /// Data massima consentita.
+    /// </summary>
+    public DateTime? MaxDate
+    {
+        get => (DateTime?)GetValue(MaxDateProperty);
+        set => SetValue(MaxDateProperty, value);
+    }
+
+    /// <summary>
+    /// Indica se la data deve essere futura.
+    /// </summary>
+    public bool MustBeFutureDate
+    {
+        get => (bool)GetValue(MustBeFutureDateProperty);
+        set => SetValue(MustBeFutureDateProperty, value);
+    }
+
+    /// <summary>
+    /// Messaggio di errore di validazione.
+    /// </summary>
+    public string ValidationError
+    {
+        get => (string)GetValue(ValidationErrorProperty);
+        private set => SetValue(ValidationErrorProperty, value);
+    }
+
+    /// <summary>
+    /// Indica se ci sono errori di validazione.
+    /// </summary>
+    public bool HasValidationError
+    {
+        get => (bool)GetValue(HasValidationErrorProperty);
+        private set => SetValue(HasValidationErrorProperty, value);
+    }
+
+    public PtrpDatePicker()
+    {
+        InitializeComponent();
+    }
+
+    private static void OnSelectedDateChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is PtrpDatePicker picker)
+        {
+            picker.ValidateDate();
+        }
+    }
+
+    private static void OnValidationPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is PtrpDatePicker picker)
+        {
+            picker.ValidateDate();
+        }
+    }
+
+    private void ValidateDate()
+    {
+        ValidationError = string.Empty;
+        HasValidationError = false;
+
+        // Required validation
+        if (IsRequired && !SelectedDate.HasValue)
+        {
+            ValidationError = "La data è obbligatoria";
+            HasValidationError = true;
+            return;
+        }
+
+        if (!SelectedDate.HasValue)
+            return;
+
+        var date = SelectedDate.Value;
+
+        // Future date validation
+        if (MustBeFutureDate && date.Date < DateTime.Today)
+        {
+            ValidationError = "La data deve essere futura";
+            HasValidationError = true;
+            return;
+        }
+
+        // Min date validation
+        if (MinDate.HasValue && date < MinDate.Value)
+        {
+            ValidationError = $"La data deve essere successiva al {MinDate.Value:dd/MM/yyyy}";
+            HasValidationError = true;
+            return;
+        }
+
+        // Max date validation
+        if (MaxDate.HasValue && date > MaxDate.Value)
+        {
+            ValidationError = $"La data deve essere precedente al {MaxDate.Value:dd/MM/yyyy}";
+            HasValidationError = true;
+            return;
+        }
+    }
+
+    /// <summary>
+    /// Valida manualmente il controllo e restituisce true se valido.
+    /// </summary>
+    public bool Validate()
+    {
+        ValidateDate();
+        return !HasValidationError;
+    }
+}

--- a/src/PTRP.App/Controls/PtrpTimePicker.xaml
+++ b/src/PTRP.App/Controls/PtrpTimePicker.xaml
@@ -1,0 +1,27 @@
+<UserControl x:Class="PTRP.App.Controls.PtrpTimePicker"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             mc:Ignorable="d" 
+             d:DesignHeight="60" d:DesignWidth="200"
+             x:Name="Root">
+    <StackPanel>
+        <materialDesign:TimePicker x:Name="InternalTimePicker"
+                                   SelectedTime="{Binding SelectedTime, ElementName=Root, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                   materialDesign:HintAssist.Hint="{Binding Watermark, ElementName=Root}"
+                                   Style="{StaticResource MaterialDesignFloatingHintTimePicker}"
+                                   Is24Hours="True"
+                                   WithSeconds="False"
+                                   Margin="0,0,0,4"
+                                   FontSize="14"/>
+        
+        <!-- Validation Error Message -->
+        <TextBlock Text="{Binding ValidationError, ElementName=Root}"
+                   Foreground="#D32F2F"
+                   FontSize="12"
+                   Margin="0,2,0,0"
+                   Visibility="{Binding HasValidationError, ElementName=Root, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+    </StackPanel>
+</UserControl>

--- a/src/PTRP.App/Controls/PtrpTimePicker.xaml.cs
+++ b/src/PTRP.App/Controls/PtrpTimePicker.xaml.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace PTRP.App.Controls;
+
+/// <summary>
+/// Controllo TimePicker personalizzato con stile Material Design e supporto validazione.
+/// </summary>
+/// <remarks>
+/// Supporta:
+/// - Validazione required
+/// - Validazione time range (MinTime, MaxTime)
+/// - Formato 24 ore (HH:mm)
+/// - Messaggio di errore personalizzabile
+/// </remarks>
+/// <example>
+/// <code>
+/// &lt;controls:PtrpTimePicker 
+///     SelectedTime="{Binding StartTime}" 
+///     Watermark="Ora Inizio"
+///     IsRequired="True" /&gt;
+/// </code>
+/// </example>
+public partial class PtrpTimePicker : UserControl
+{
+    public static readonly DependencyProperty SelectedTimeProperty =
+        DependencyProperty.Register(
+            nameof(SelectedTime),
+            typeof(TimeSpan?),
+            typeof(PtrpTimePicker),
+            new FrameworkPropertyMetadata(
+                null,
+                FrameworkPropertyMetadataOptions.BindsTwoWayByDefault,
+                OnSelectedTimeChanged));
+
+    public static readonly DependencyProperty WatermarkProperty =
+        DependencyProperty.Register(
+            nameof(Watermark),
+            typeof(string),
+            typeof(PtrpTimePicker),
+            new PropertyMetadata("Seleziona ora"));
+
+    public static readonly DependencyProperty IsRequiredProperty =
+        DependencyProperty.Register(
+            nameof(IsRequired),
+            typeof(bool),
+            typeof(PtrpTimePicker),
+            new PropertyMetadata(false, OnValidationPropertyChanged));
+
+    public static readonly DependencyProperty MinTimeProperty =
+        DependencyProperty.Register(
+            nameof(MinTime),
+            typeof(TimeSpan?),
+            typeof(PtrpTimePicker),
+            new PropertyMetadata(null, OnValidationPropertyChanged));
+
+    public static readonly DependencyProperty MaxTimeProperty =
+        DependencyProperty.Register(
+            nameof(MaxTime),
+            typeof(TimeSpan?),
+            typeof(PtrpTimePicker),
+            new PropertyMetadata(null, OnValidationPropertyChanged));
+
+    public static readonly DependencyProperty ValidationErrorProperty =
+        DependencyProperty.Register(
+            nameof(ValidationError),
+            typeof(string),
+            typeof(PtrpTimePicker),
+            new PropertyMetadata(string.Empty));
+
+    public static readonly DependencyProperty HasValidationErrorProperty =
+        DependencyProperty.Register(
+            nameof(HasValidationError),
+            typeof(bool),
+            typeof(PtrpTimePicker),
+            new PropertyMetadata(false));
+
+    /// <summary>
+    /// Ora selezionata.
+    /// </summary>
+    public TimeSpan? SelectedTime
+    {
+        get => (TimeSpan?)GetValue(SelectedTimeProperty);
+        set => SetValue(SelectedTimeProperty, value);
+    }
+
+    /// <summary>
+    /// Testo placeholder quando nessuna ora è selezionata.
+    /// </summary>
+    public string Watermark
+    {
+        get => (string)GetValue(WatermarkProperty);
+        set => SetValue(WatermarkProperty, value);
+    }
+
+    /// <summary>
+    /// Indica se l'ora è obbligatoria.
+    /// </summary>
+    public bool IsRequired
+    {
+        get => (bool)GetValue(IsRequiredProperty);
+        set => SetValue(IsRequiredProperty, value);
+    }
+
+    /// <summary>
+    /// Ora minima consentita.
+    /// </summary>
+    public TimeSpan? MinTime
+    {
+        get => (TimeSpan?)GetValue(MinTimeProperty);
+        set => SetValue(MinTimeProperty, value);
+    }
+
+    /// <summary>
+    /// Ora massima consentita.
+    /// </summary>
+    public TimeSpan? MaxTime
+    {
+        get => (TimeSpan?)GetValue(MaxTimeProperty);
+        set => SetValue(MaxTimeProperty, value);
+    }
+
+    /// <summary>
+    /// Messaggio di errore di validazione.
+    /// </summary>
+    public string ValidationError
+    {
+        get => (string)GetValue(ValidationErrorProperty);
+        private set => SetValue(ValidationErrorProperty, value);
+    }
+
+    /// <summary>
+    /// Indica se ci sono errori di validazione.
+    /// </summary>
+    public bool HasValidationError
+    {
+        get => (bool)GetValue(HasValidationErrorProperty);
+        private set => SetValue(HasValidationErrorProperty, value);
+    }
+
+    public PtrpTimePicker()
+    {
+        InitializeComponent();
+    }
+
+    private static void OnSelectedTimeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is PtrpTimePicker picker)
+        {
+            picker.ValidateTime();
+        }
+    }
+
+    private static void OnValidationPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is PtrpTimePicker picker)
+        {
+            picker.ValidateTime();
+        }
+    }
+
+    private void ValidateTime()
+    {
+        ValidationError = string.Empty;
+        HasValidationError = false;
+
+        // Required validation
+        if (IsRequired && !SelectedTime.HasValue)
+        {
+            ValidationError = "L'ora è obbligatoria";
+            HasValidationError = true;
+            return;
+        }
+
+        if (!SelectedTime.HasValue)
+            return;
+
+        var time = SelectedTime.Value;
+
+        // Min time validation
+        if (MinTime.HasValue && time < MinTime.Value)
+        {
+            ValidationError = $"L'ora deve essere successiva alle {MinTime.Value:hh\\:mm}";
+            HasValidationError = true;
+            return;
+        }
+
+        // Max time validation
+        if (MaxTime.HasValue && time > MaxTime.Value)
+        {
+            ValidationError = $"L'ora deve essere precedente alle {MaxTime.Value:hh\\:mm}";
+            HasValidationError = true;
+            return;
+        }
+    }
+
+    /// <summary>
+    /// Valida manualmente il controllo e restituisce true se valido.
+    /// </summary>
+    public bool Validate()
+    {
+        ValidateTime();
+        return !HasValidationError;
+    }
+}

--- a/src/PTRP.App/Controls/SearchBox.xaml
+++ b/src/PTRP.App/Controls/SearchBox.xaml
@@ -1,0 +1,45 @@
+<UserControl x:Class="PTRP.App.Controls.SearchBox"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             mc:Ignorable="d" 
+             d:DesignHeight="50" d:DesignWidth="350"
+             x:Name="Root">
+    <Grid>
+        <TextBox x:Name="InternalTextBox"
+                 Text="{Binding SearchText, ElementName=Root, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                 materialDesign:HintAssist.Hint="{Binding Watermark, ElementName=Root}"
+                 Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                 FontSize="14"
+                 Padding="32,8,32,8"
+                 TextChanged="OnTextChanged"/>
+        
+        <!-- Search Icon -->
+        <materialDesign:PackIcon Kind="Magnify"
+                                 Width="20"
+                                 Height="20"
+                                 Foreground="{DynamicResource MaterialDesignBody}"
+                                 VerticalAlignment="Center"
+                                 HorizontalAlignment="Left"
+                                 Margin="8,0,0,0"
+                                 IsHitTestVisible="False"/>
+        
+        <!-- Clear Button -->
+        <Button x:Name="ClearButton"
+                Style="{StaticResource MaterialDesignToolButton}"
+                Width="24"
+                Height="24"
+                Padding="0"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Center"
+                Margin="0,0,4,0"
+                Click="OnClearClick"
+                Visibility="{Binding HasText, ElementName=Root, Converter={StaticResource BooleanToVisibilityConverter}}">
+            <materialDesign:PackIcon Kind="Close"
+                                     Width="18"
+                                     Height="18"/>
+        </Button>
+    </Grid>
+</UserControl>

--- a/src/PTRP.App/Controls/SearchBox.xaml.cs
+++ b/src/PTRP.App/Controls/SearchBox.xaml.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Threading;
+
+namespace PTRP.App.Controls;
+
+/// <summary>
+/// Controllo di ricerca con debouncing automatico e pulsante clear.
+/// </summary>
+/// <remarks>
+/// - Debouncing: 300ms di ritardo prima di triggerare SearchCommand dopo l'ultima digitazione
+/// - Pulsante Clear: appare automaticamente quando c'è testo e pulisce il campo
+/// - SearchCommand: comando eseguito dopo il debouncing
+/// </remarks>
+/// <example>
+/// <code>
+/// &lt;controls:SearchBox 
+///     SearchText="{Binding SearchTerm}" 
+///     SearchCommand="{Binding SearchCommand}"
+///     Watermark="Cerca pazienti..." /&gt;
+/// </code>
+/// </example>
+public partial class SearchBox : UserControl
+{
+    private DispatcherTimer? _debounceTimer;
+    private const int DebounceMilliseconds = 300;
+
+    public static readonly DependencyProperty SearchTextProperty =
+        DependencyProperty.Register(
+            nameof(SearchText),
+            typeof(string),
+            typeof(SearchBox),
+            new FrameworkPropertyMetadata(
+                string.Empty,
+                FrameworkPropertyMetadataOptions.BindsTwoWayByDefault,
+                OnSearchTextChanged));
+
+    public static readonly DependencyProperty WatermarkProperty =
+        DependencyProperty.Register(
+            nameof(Watermark),
+            typeof(string),
+            typeof(SearchBox),
+            new PropertyMetadata("Cerca..."));
+
+    public static readonly DependencyProperty SearchCommandProperty =
+        DependencyProperty.Register(
+            nameof(SearchCommand),
+            typeof(ICommand),
+            typeof(SearchBox),
+            new PropertyMetadata(null));
+
+    public static readonly DependencyProperty HasTextProperty =
+        DependencyProperty.Register(
+            nameof(HasText),
+            typeof(bool),
+            typeof(SearchBox),
+            new PropertyMetadata(false));
+
+    /// <summary>
+    /// Testo di ricerca.
+    /// </summary>
+    public string SearchText
+    {
+        get => (string)GetValue(SearchTextProperty);
+        set => SetValue(SearchTextProperty, value);
+    }
+
+    /// <summary>
+    /// Testo placeholder.
+    /// </summary>
+    public string Watermark
+    {
+        get => (string)GetValue(WatermarkProperty);
+        set => SetValue(WatermarkProperty, value);
+    }
+
+    /// <summary>
+    /// Comando eseguito dopo il debouncing (300ms).
+    /// </summary>
+    public ICommand? SearchCommand
+    {
+        get => (ICommand?)GetValue(SearchCommandProperty);
+        set => SetValue(SearchCommandProperty, value);
+    }
+
+    /// <summary>
+    /// Indica se c'è testo nella searchbox (per mostrare il pulsante Clear).
+    /// </summary>
+    public bool HasText
+    {
+        get => (bool)GetValue(HasTextProperty);
+        private set => SetValue(HasTextProperty, value);
+    }
+
+    public SearchBox()
+    {
+        InitializeComponent();
+        InitializeDebounceTimer();
+    }
+
+    private void InitializeDebounceTimer()
+    {
+        _debounceTimer = new DispatcherTimer
+        {
+            Interval = TimeSpan.FromMilliseconds(DebounceMilliseconds)
+        };
+        _debounceTimer.Tick += OnDebounceTimerTick;
+    }
+
+    private static void OnSearchTextChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is SearchBox searchBox)
+        {
+            searchBox.HasText = !string.IsNullOrWhiteSpace(searchBox.SearchText);
+        }
+    }
+
+    private void OnTextChanged(object sender, TextChangedEventArgs e)
+    {
+        // Reset debounce timer ogni volta che l'utente digita
+        _debounceTimer?.Stop();
+        _debounceTimer?.Start();
+    }
+
+    private void OnDebounceTimerTick(object? sender, EventArgs e)
+    {
+        _debounceTimer?.Stop();
+
+        // Trigger SearchCommand dopo il debouncing
+        if (SearchCommand?.CanExecute(SearchText) == true)
+        {
+            SearchCommand.Execute(SearchText);
+        }
+    }
+
+    private void OnClearClick(object sender, RoutedEventArgs e)
+    {
+        SearchText = string.Empty;
+        InternalTextBox.Focus();
+
+        // Trigger immediato quando si pulisce
+        if (SearchCommand?.CanExecute(string.Empty) == true)
+        {
+            SearchCommand.Execute(string.Empty);
+        }
+    }
+}

--- a/src/PTRP.App/Controls/StatusBadge.xaml
+++ b/src/PTRP.App/Controls/StatusBadge.xaml
@@ -1,0 +1,26 @@
+<UserControl x:Class="PTRP.App.Controls.StatusBadge"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:PTRP.App.Controls"
+             xmlns:converters="clr-namespace:PTRP.App.Converters"
+             mc:Ignorable="d" 
+             d:DesignHeight="30" d:DesignWidth="120"
+             x:Name="Root">
+    <UserControl.Resources>
+        <converters:ProjectStateToColorConverter x:Key="StateToColorConverter"/>
+    </UserControl.Resources>
+    
+    <Border CornerRadius="12" 
+            Padding="8,4"
+            Background="{Binding Status, ElementName=Root, Converter={StaticResource StateToColorConverter}}"
+            HorizontalAlignment="Left"
+            VerticalAlignment="Center">
+        <TextBlock Text="{Binding StatusDisplay, ElementName=Root}"
+                   FontSize="12"
+                   FontWeight="SemiBold"
+                   Foreground="White"
+                   VerticalAlignment="Center"/>
+    </Border>
+</UserControl>

--- a/src/PTRP.App/Controls/StatusBadge.xaml.cs
+++ b/src/PTRP.App/Controls/StatusBadge.xaml.cs
@@ -1,0 +1,64 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace PTRP.App.Controls;
+
+/// <summary>
+/// Badge colorato per visualizzare lo stato di un'entità (Progetto, Appuntamento, ecc.).
+/// Auto-styling basato sul valore dello stato.
+/// </summary>
+/// <remarks>
+/// Supporta TherapyProjectState, AppointmentStatus, PresenceStatus.
+/// Il colore viene determinato automaticamente tramite ProjectStateToColorConverter.
+/// </remarks>
+/// <example>
+/// <code>
+/// &lt;controls:StatusBadge Status="Active" StatusDisplay="Attivo" /&gt;
+/// &lt;controls:StatusBadge Status="Completed" StatusDisplay="Completato" /&gt;
+/// </code>
+/// </example>
+public partial class StatusBadge : UserControl
+{
+    /// <summary>
+    /// Dependency property per lo stato (enum convertito a string).
+    /// </summary>
+    public static readonly DependencyProperty StatusProperty =
+        DependencyProperty.Register(
+            nameof(Status),
+            typeof(string),
+            typeof(StatusBadge),
+            new PropertyMetadata(string.Empty));
+
+    /// <summary>
+    /// Dependency property per il testo visualizzato.
+    /// </summary>
+    public static readonly DependencyProperty StatusDisplayProperty =
+        DependencyProperty.Register(
+            nameof(StatusDisplay),
+            typeof(string),
+            typeof(StatusBadge),
+            new PropertyMetadata(string.Empty));
+
+    /// <summary>
+    /// Valore dello stato (es: "Active", "Completed", "Scheduled").
+    /// </summary>
+    public string Status
+    {
+        get => (string)GetValue(StatusProperty);
+        set => SetValue(StatusProperty, value);
+    }
+
+    /// <summary>
+    /// Testo da visualizzare nel badge (es: "Attivo", "Completato", "Programmato").
+    /// </summary>
+    public string StatusDisplay
+    {
+        get => (string)GetValue(StatusDisplayProperty);
+        set => SetValue(StatusDisplayProperty, value);
+    }
+
+    public StatusBadge()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
feat: creare componenti UI riutilizzabili (issue #83)

Questo PR introduce una prima libreria di controlli riutilizzabili per la UI WPF, in linea con l'analisi della issue #83.

## Contenuto

### 1. Nuova cartella Controls
- `src/PTRP.App/Controls/`

### 2. StatusBadge
- `StatusBadge.xaml`
- `StatusBadge.xaml.cs`

Badge colorato per visualizzare lo stato di entità come TherapyProject, Appointment, Presence.
- Usa `ProjectStateToColorConverter` esistente per determinare il colore
- Espone DP:
  - `Status` (string)
  - `StatusDisplay` (string)

### 3. PtrpDatePicker
- `PtrpDatePicker.xaml`
- `PtrpDatePicker.xaml.cs`

DatePicker con stile Material Design e supporto validazione:
- DP:
  - `SelectedDate` (DateTime?)
  - `Watermark` (string)
  - `IsRequired` (bool)
  - `MinDate` / `MaxDate` (DateTime?)
  - `MustBeFutureDate` (bool)
- Validazioni lato controllo con messaggio di errore inline.

### 4. PtrpTimePicker
- `PtrpTimePicker.xaml`
- `PtrpTimePicker.xaml.cs`

TimePicker (MaterialDesign) in formato 24h (HH:mm) con validazione:
- DP:
  - `SelectedTime` (TimeSpan?)
  - `Watermark` (string)
  - `IsRequired` (bool)
  - `MinTime` / `MaxTime` (TimeSpan?)

### 5. SearchBox
- `SearchBox.xaml`
- `SearchBox.xaml.cs`

TextBox con:
- icona search integrata
- pulsante clear
- debouncing 300ms prima di eseguire `SearchCommand`
- DP:
  - `SearchText` (string)
  - `Watermark` (string)
  - `SearchCommand` (ICommand)

### 6. KpiCard
- `KpiCard.xaml`
- `KpiCard.xaml.cs`

Card per KPI con:
- icona (PackIconKind)
- valore principale
- titolo
- trend opzionale (es: `+5.2%`, `-3.1%`)

### 7. ActionButtonsGroup
- `ActionButtonsGroup.xaml`
- `ActionButtonsGroup.xaml.cs`

Gruppo standard per form/detail:
- Modalità Save/Cancel
- Modalità Edit/Delete
- DP per comandi e testi

## Note
- I controlli sono auto-contenuti e utilizzano solo risorse globali già presenti (MaterialDesign theme, BooleanToVisibilityConverter).
- Non sono ancora stati cablati nelle view esistenti (#50, #51, #74, #75): questo potrà essere fatto in una PR successiva per ridurre la dimensione del diff.

## Step successivi suggeriti
- Integrare `StatusBadge` in PatientListView / ProjectFormView.
- Integrare `PtrpDatePicker` e `PtrpTimePicker` in ProjectFormView e VisitFormView.
- Usare `SearchBox` in PatientListView.
- Usare `KpiCard` nella Dashboard.
- Usare `ActionButtonsGroup` in form e detail view per pulsanti consistenti.
