### PR TITLE
fix: CI coverage reportgenerator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,10 @@ jobs:
           -- RunConfiguration.DisableAppDomain=true
     
     - name: Generate coverage report
+      shell: pwsh
       run: |
-        dotnet tool install -g reportgenerator
+        dotnet tool install -g dotnet-reportgenerator-globaltool
+        $env:PATH += ";$env:USERPROFILE\.dotnet\tools"
         reportgenerator -reports:"**/coverage.cobertura.xml" -targetdir:"./coverage-report" -reporttypes:Html
       continue-on-error: true
     


### PR DESCRIPTION
fix: CI coverage reportgenerator

Questo PR corregge la generazione del report di coverage nella pipeline CI:

- Usa il package corretto `dotnet-reportgenerator-globaltool` come .NET tool globale
- Aggiunge la cartella degli strumenti globali (`$env:USERPROFILE\.dotnet\tools`) al PATH nella step che esegue `reportgenerator`
- Esegue il comando in shell PowerShell (`pwsh`), coerente con la sintassi usata

In questo modo il job `Test & Coverage` non fallisce più quando genera il report HTML della coverage.
